### PR TITLE
Handle multiple applications connecting to the database

### DIFF
--- a/lib/charms/data_platform_libs/v0/database_provides.py
+++ b/lib/charms/data_platform_libs/v0/database_provides.py
@@ -219,9 +219,6 @@ class DatabaseProvides(Object):
         This function writes in the application data bag, therefore,
         only the leader unit can call it.
 
-        This function can be used to set the data
-        when outside an event callback.
-
         Args:
             relation_id: the identifier for a particular relation.
             username: user that was created.
@@ -241,9 +238,6 @@ class DatabaseProvides(Object):
         This function writes in the application data bag, therefore,
         only the leader unit can call it.
 
-        This function can be used to set the data
-        when outside an event callback.
-
         Args:
             relation_id: the identifier for a particular relation.
             connection_strings: database hosts and ports comma separated list.
@@ -256,9 +250,6 @@ class DatabaseProvides(Object):
         This function writes in the application data bag, therefore,
         only the leader unit can call it.
 
-        This function can be used to set the data
-        when outside an event callback.
-
         Args:
             relation_id: the identifier for a particular relation.
             connection_strings: database hosts and ports comma separated list.
@@ -270,9 +261,6 @@ class DatabaseProvides(Object):
 
         MongoDB only.
 
-        This function can be used to set the data
-        when outside an event callback.
-
         Args:
             relation_id: the identifier for a particular relation.
             replset: replica set name.
@@ -282,9 +270,6 @@ class DatabaseProvides(Object):
     def set_tls(self, relation_id: int, tls: str) -> None:
         """Set whether TLS is enabled.
 
-        This function can be used to set the data
-        when outside an event callback.
-
         Args:
             relation_id: the identifier for a particular relation.
             tls: whether tls is enabled (True or False).
@@ -293,9 +278,6 @@ class DatabaseProvides(Object):
 
     def set_tls_ca(self, relation_id: int, tls_ca: str) -> None:
         """Set the TLS CA in the application relation databag.
-
-        This function can be used to set the data
-        when outside an event callback.
 
         Args:
             relation_id: the identifier for a particular relation.
@@ -308,9 +290,6 @@ class DatabaseProvides(Object):
 
         MongoDB, Redis, OpenSearch and Kafka only.
 
-        This function can be used to set the data
-        when outside an event callback.
-
         Args:
             relation_id: the identifier for a particular relation.
             uris: connection URIs.
@@ -319,9 +298,6 @@ class DatabaseProvides(Object):
 
     def set_version(self, relation_id: int, version: str) -> None:
         """Set the database version in the application relation databag.
-
-        This function can be used to set the data
-        when outside an event callback.
 
         Args:
             relation_id: the identifier for a particular relation.

--- a/tests/integration/application-charm/src/charm.py
+++ b/tests/integration/application-charm/src/charm.py
@@ -17,8 +17,6 @@ from ops.model import ActiveStatus
 
 logger = logging.getLogger(__name__)
 
-# Name of the database that this application requests to the database charm.
-DATABASE = "data_platform"
 # Extra roles that this application needs when interacting with the database.
 EXTRA_USER_ROLES = "CREATEDB,CREATEROLE"
 
@@ -32,8 +30,10 @@ class ApplicationCharm(CharmBase):
         # Default charm events.
         self.framework.observe(self.on.start, self._on_start)
 
+        # Name of the database that this application requests to the database charm.
+        database = f'data_platform_{self.app.name.replace("-", "_")}'
         # Charm events defined in the database requires charm library.
-        self.database = DatabaseRequires(self, "database", DATABASE, EXTRA_USER_ROLES)
+        self.database = DatabaseRequires(self, "database", database, EXTRA_USER_ROLES)
         self.framework.observe(self.database.on.database_created, self._on_database_created)
         self.framework.observe(self.database.on.endpoints_changed, self._on_endpoints_changed)
 

--- a/tests/integration/database-charm/src/charm.py
+++ b/tests/integration/database-charm/src/charm.py
@@ -97,14 +97,16 @@ class DatabaseCharm(CharmBase):
         connection.close()
 
         # Share the credentials with the application.
-        event.set_credentials(username, password)
+        self.database.set_credentials(event.relation.id, username, password)
 
         # Set the read/write endpoint.
-        event.set_endpoints(f'{self.model.get_binding("database").network.bind_address}:5432')
+        self.database.set_endpoints(
+            event.relation.id, f'{self.model.get_binding("database").network.bind_address}:5432'
+        )
 
         # Share additional information with the application.
-        event.set_tls("False")
-        event.set_version(version)
+        self.database.set_tls(event.relation.id, "False")
+        self.database.set_version(event.relation.id, version)
 
         self.unit.status = ActiveStatus()
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -18,13 +18,14 @@ async def build_connection_string(ops_test: OpsTest, application_name: str) -> s
         a PostgreSQL connection string
     """
     # Get the connection data exposed to the application through the relation.
+    database = f'data_platform_{application_name.replace("-", "_")}'
     username = await get_application_relation_data(ops_test, application_name, "username")
     password = await get_application_relation_data(ops_test, application_name, "password")
     endpoints = await get_application_relation_data(ops_test, application_name, "endpoints")
     host = endpoints.split(",")[0].split(":")[0]
 
     # Build the complete connection string to connect to the database.
-    return f"dbname='data_platform' user='{username}' host='{host}' password='{password}' connect_timeout=10"
+    return f"dbname='{database}' user='{username}' host='{host}' password='{password}' connect_timeout=10"
 
 
 async def get_application_relation_data(

--- a/tests/unit/test_database_provides.py
+++ b/tests/unit/test_database_provides.py
@@ -45,11 +45,21 @@ class TestDatabaseProvides(unittest.TestCase):
         self.harness.set_leader(True)
         self.harness.begin_with_initial_hooks()
 
+    @patch.object(DatabaseCharm, "_on_database_requested")
+    def emit_database_requested_event(self, _on_database_requested):
+        # Emit the database requested event.
+        relation = self.harness.charm.model.get_relation(RELATION_NAME, self.rel_id)
+        application = self.harness.charm.model.get_app("database")
+        self.harness.charm.database.on.database_requested.emit(relation, application)
+        return _on_database_requested.call_args[0][0]
+
     def test_diff(self):
         """Asserts that the charm library correctly returns a diff of the relation data."""
         # Define a mock relation changed event to be used in the subsequent diff calls.
         mock_event = Mock()
-        # Set the initial data for the event.
+        # Set the app, id and the initial data for the relation.
+        mock_event.app = self.harness.charm.model.get_app("database")
+        mock_event.relation.id = self.rel_id
         mock_event.relation.data = {
             mock_event.app: {"username": "test-username", "password": "test-password"}
         }
@@ -85,19 +95,35 @@ class TestDatabaseProvides(unittest.TestCase):
             {"database": DATABASE, "extra-user-roles": EXTRA_USER_ROLES},
         )
 
-        # Assert the database name is accessible in the providers charm library.
-        assert self.harness.charm.database.database == DATABASE
-        assert self.harness.charm.database.extra_user_roles == EXTRA_USER_ROLES
-
         # Assert the correct hook is called.
         _on_database_requested.assert_called_once()
+
+        # Assert the database name and the extra user roles
+        # are accessible in the providers charm library event.
+        event = _on_database_requested.call_args[0][0]
+        assert event.database == DATABASE
+        assert event.extra_user_roles == EXTRA_USER_ROLES
 
     def test_set_credentials(self):
         """Asserts that the database name is in the relation databag when it's requested."""
         # Set the credentials in the relation using the provides charm library.
-        self.harness.charm.database.set_credentials("test-username", "test-password")
+        self.harness.charm.database.set_credentials(self.rel_id, "test-username", "test-password")
 
-        # Check that the database name is present in the relation.
+        # Check that the credentials are present in the relation.
+        assert self.harness.get_relation_data(self.rel_id, "database") == {
+            "data": "{}",  # Data is the diff stored between multiple relation changed events.
+            "username": "test-username",
+            "password": "test-password",
+        }
+
+    def test_event_set_credentials(self):
+        # Emit an event to use it later.
+        event = self.emit_database_requested_event()
+
+        # Set the credentials using the event function.
+        event.set_credentials("test-username", "test-password")
+
+        # Check that the credentials are present in the relation.
         assert self.harness.get_relation_data(self.rel_id, "database") == {
             "data": "{}",  # Data is the diff stored between multiple relation changed events.
             "username": "test-username",
@@ -107,7 +133,20 @@ class TestDatabaseProvides(unittest.TestCase):
     def test_set_endpoints(self):
         """Asserts that the endpoints are in the relation databag when they change."""
         # Set the endpoints in the relation using the provides charm library.
-        self.harness.charm.database.set_endpoints("host1:port,host2:port")
+        self.harness.charm.database.set_endpoints(self.rel_id, "host1:port,host2:port")
+
+        # Check that the endpoints are present in the relation.
+        assert (
+            self.harness.get_relation_data(self.rel_id, "database")["endpoints"]
+            == "host1:port,host2:port"
+        )
+
+    def test_event_set_endpoints(self):
+        # Emit an event to use it later.
+        event = self.emit_database_requested_event()
+
+        # Set the endpoints using the event function.
+        event.set_endpoints("host1:port,host2:port")
 
         # Check that the endpoints are present in the relation.
         assert (
@@ -118,7 +157,20 @@ class TestDatabaseProvides(unittest.TestCase):
     def test_set_read_only_endpoints(self):
         """Asserts that the read only endpoints are in the relation databag when they change."""
         # Set the endpoints in the relation using the provides charm library.
-        self.harness.charm.database.set_read_only_endpoints("host1:port,host2:port")
+        self.harness.charm.database.set_read_only_endpoints(self.rel_id, "host1:port,host2:port")
+
+        # Check that the endpoints are present in the relation.
+        assert (
+            self.harness.get_relation_data(self.rel_id, "database")["read-only-endpoints"]
+            == "host1:port,host2:port"
+        )
+
+    def test_event_set_read_only_endpoints(self):
+        # Emit an event to use it later.
+        event = self.emit_database_requested_event()
+
+        # Set the endpoints using the event function.
+        event.set_read_only_endpoints("host1:port,host2:port")
 
         # Check that the endpoints are present in the relation.
         assert (
@@ -129,11 +181,11 @@ class TestDatabaseProvides(unittest.TestCase):
     def test_set_additional_fields(self):
         """Asserts that the additional fields are in the relation databag when they are set."""
         # Set the additional fields in the relation using the provides charm library.
-        self.harness.charm.database.set_replset("rs0")
-        self.harness.charm.database.set_tls("True")
-        self.harness.charm.database.set_tls_ca("Canonical")
-        self.harness.charm.database.set_uris("host1:port,host2:port")
-        self.harness.charm.database.set_version("1.0")
+        self.harness.charm.database.set_replset(self.rel_id, "rs0")
+        self.harness.charm.database.set_tls(self.rel_id, "True")
+        self.harness.charm.database.set_tls_ca(self.rel_id, "Canonical")
+        self.harness.charm.database.set_uris(self.rel_id, "host1:port,host2:port")
+        self.harness.charm.database.set_version(self.rel_id, "1.0")
 
         # Check that the additional fields are present in the relation.
         assert self.harness.get_relation_data(self.rel_id, "database") == {
@@ -144,3 +196,33 @@ class TestDatabaseProvides(unittest.TestCase):
             "uris": "host1:port,host2:port",
             "version": "1.0",
         }
+
+    def test_event_set_additional_fields(self):
+        # Emit an event to use it later.
+        event = self.emit_database_requested_event()
+
+        # Set the additional fields using the event function.
+        event.set_replset("rs0")
+        event.set_tls("True")
+        event.set_tls_ca("Canonical")
+        event.set_uris("host1:port,host2:port")
+        event.set_version("1.0")
+
+        # Check that the additional fields are present in the relation.
+        assert self.harness.get_relation_data(self.rel_id, "database") == {
+            "data": "{}",  # Data is the diff stored between multiple relation changed events.
+            "replset": "rs0",
+            "tls": "True",
+            "tls_ca": "Canonical",
+            "uris": "host1:port,host2:port",
+            "version": "1.0",
+        }
+
+    def test_fetch_relation_data(self):
+        # Set some data in the relation.
+        self.harness.update_relation_data(self.rel_id, "application", {"database": DATABASE})
+
+        # Check the data using the charm library function
+        # (the diff/data key should not be present).
+        data = self.harness.charm.database.fetch_relation_data()
+        assert data == {self.rel_id: {"database": DATABASE}}

--- a/tests/unit/test_database_provides.py
+++ b/tests/unit/test_database_provides.py
@@ -116,37 +116,10 @@ class TestDatabaseProvides(unittest.TestCase):
             "password": "test-password",
         }
 
-    def test_event_set_credentials(self):
-        # Emit an event to use it later.
-        event = self.emit_database_requested_event()
-
-        # Set the credentials using the event function.
-        event.set_credentials("test-username", "test-password")
-
-        # Check that the credentials are present in the relation.
-        assert self.harness.get_relation_data(self.rel_id, "database") == {
-            "data": "{}",  # Data is the diff stored between multiple relation changed events.
-            "username": "test-username",
-            "password": "test-password",
-        }
-
     def test_set_endpoints(self):
         """Asserts that the endpoints are in the relation databag when they change."""
         # Set the endpoints in the relation using the provides charm library.
         self.harness.charm.database.set_endpoints(self.rel_id, "host1:port,host2:port")
-
-        # Check that the endpoints are present in the relation.
-        assert (
-            self.harness.get_relation_data(self.rel_id, "database")["endpoints"]
-            == "host1:port,host2:port"
-        )
-
-    def test_event_set_endpoints(self):
-        # Emit an event to use it later.
-        event = self.emit_database_requested_event()
-
-        # Set the endpoints using the event function.
-        event.set_endpoints("host1:port,host2:port")
 
         # Check that the endpoints are present in the relation.
         assert (
@@ -165,19 +138,6 @@ class TestDatabaseProvides(unittest.TestCase):
             == "host1:port,host2:port"
         )
 
-    def test_event_set_read_only_endpoints(self):
-        # Emit an event to use it later.
-        event = self.emit_database_requested_event()
-
-        # Set the endpoints using the event function.
-        event.set_read_only_endpoints("host1:port,host2:port")
-
-        # Check that the endpoints are present in the relation.
-        assert (
-            self.harness.get_relation_data(self.rel_id, "database")["read-only-endpoints"]
-            == "host1:port,host2:port"
-        )
-
     def test_set_additional_fields(self):
         """Asserts that the additional fields are in the relation databag when they are set."""
         # Set the additional fields in the relation using the provides charm library.
@@ -186,27 +146,6 @@ class TestDatabaseProvides(unittest.TestCase):
         self.harness.charm.database.set_tls_ca(self.rel_id, "Canonical")
         self.harness.charm.database.set_uris(self.rel_id, "host1:port,host2:port")
         self.harness.charm.database.set_version(self.rel_id, "1.0")
-
-        # Check that the additional fields are present in the relation.
-        assert self.harness.get_relation_data(self.rel_id, "database") == {
-            "data": "{}",  # Data is the diff stored between multiple relation changed events.
-            "replset": "rs0",
-            "tls": "True",
-            "tls_ca": "Canonical",
-            "uris": "host1:port,host2:port",
-            "version": "1.0",
-        }
-
-    def test_event_set_additional_fields(self):
-        # Emit an event to use it later.
-        event = self.emit_database_requested_event()
-
-        # Set the additional fields using the event function.
-        event.set_replset("rs0")
-        event.set_tls("True")
-        event.set_tls_ca("Canonical")
-        event.set_uris("host1:port,host2:port")
-        event.set_version("1.0")
 
         # Check that the additional fields are present in the relation.
         assert self.harness.get_relation_data(self.rel_id, "database") == {


### PR DESCRIPTION
# Issue
In short this PR address JIRA ticket [DPE-418](https://warthogs.atlassian.net/browse/DPE-418).

In long:
* Database charms using the provides charm library should be able to handle multiple applications requesting new databases.
* Currently, the library can't handle this situation. It overrides the data from the first application in the relation databag because it's using the same relation without providing a relation id (the id that differentiates the connections being made to the same relation in the database charm).

# Solution
* Use the relation id property from the relation linked to the custom events that are triggered inside the library.
* With the relation id it s possible to know which application is requesting the database and also send the credentials back.

# Context
* The documentation in the top of the library and also the database test charm were updated with the correct way to handle the relation data from one or multiple applications.
* The properties from the `DatabaseProvides` class were moved to the `DatabaseEvent` class, which is a superclass for the custom events of this library.
* The functions from the `DatabaseProvides` class now need the relation id to be passed as a parameter.
* In the `DatabaseProvides` class, there is a new function called `fetch_relation_data` to make it still be possible to retrieve the data from the relation when outside an event callback like `_on_database_requested`.

# Testing
* Unit tests were updated and some new tests (related to setting data using the event object, which is now used to set data in the right relation instance) were implemented.
* One more integration test was added to cover the case of two applications requesting new databases to the same database charm.

# Release Notes
* Make it possible to handle multiple applications requesting new databases in the provides charm library.