### PR TITLE
Add partial code to handle multiple clusters in the same relation

### DIFF
--- a/lib/charms/data_platform_libs/v0/database_requires.py
+++ b/lib/charms/data_platform_libs/v0/database_requires.py
@@ -35,14 +35,14 @@ class ApplicationCharm(CharmBase):
         self.database = DatabaseRequires(self, relation_name="database", database_name="database")
         self.framework.observe(self.database.on.database_created, self._on_database_created)
 
-    def _on_database_created(self, _) -> None:
+    def _on_database_created(self, event: DatabaseCreatedEvent) -> None:
         # Handle the created database
 
         # Create configuration file for app
         config_file = self._render_app_config_file(
-            self.database.username,
-            self.database.password,
-            self.database.endpoints,
+            event.username,
+            event.password,
+            event.endpoints,
         )
 
         # Start application with rendered configuration
@@ -57,10 +57,16 @@ import json
 import logging
 from collections import namedtuple
 from datetime import datetime
-from typing import Optional
+from typing import List, Optional
 
-from ops.charm import CharmEvents, RelationChangedEvent, RelationEvent
+from ops.charm import (
+    CharmEvents,
+    RelationChangedEvent,
+    RelationEvent,
+    RelationJoinedEvent,
+)
 from ops.framework import EventSource, Object
+from ops.model import Application, Relation
 
 # The unique Charmhub library identifier, never change it
 LIBID = "0241e088ffa9440fb4e3126349b2fb62"
@@ -75,104 +81,56 @@ LIBPATCH = 1
 logger = logging.getLogger(__name__)
 
 
-class DatabaseCreatedEvent(RelationEvent):
-    """Event emitted when a new database is created for use on this relation."""
+class DatabaseEvent(RelationEvent):
+    """Base class for database events."""
 
+    def __init__(self, handle, relation: Relation, local_app: Application):
+        super().__init__(handle, relation, relation.app, None)
+        self.local_app = local_app
 
-class DatabaseEndpointsChangedEvent(RelationEvent):
-    """Event emitted when the read/write endpoints are changed."""
+    def snapshot(self):
+        """Used by the framework to serialize the event to disk."""
+        snapshot = super(DatabaseEvent, self).snapshot()
+        if self.local_app:
+            snapshot["local_app_name"] = self.local_app.name
+        return snapshot
 
+    def restore(self, snapshot):
+        """Used by the framework to deserialize the event from disk."""
+        super(DatabaseEvent, self).restore(snapshot)
+        local_app_name = snapshot.get("local_app_name")
+        if local_app_name:
+            self.local_app = self.framework.model.get_app(local_app_name)
+        else:
+            self.local_app = None
 
-class DatabaseReadOnlyEndpointsChangedEvent(RelationEvent):
-    """Event emitted when the read only endpoints are changed."""
-
-
-class DatabaseEvents(CharmEvents):
-    """Database events.
-
-    This class defines the events that the database can emit.
-    """
-
-    database_created = EventSource(DatabaseCreatedEvent)
-    endpoints_changed = EventSource(DatabaseEndpointsChangedEvent)
-    read_only_endpoints_changed = EventSource(DatabaseReadOnlyEndpointsChangedEvent)
-
-
-Diff = namedtuple("Diff", "added changed deleted")
-Diff.__doc__ = """
-A tuple for storing the diff between two data mappings.
-
-added - keys that were added
-changed - keys that still exist but have new values
-deleted - key that were deleted"""
-
-
-class DatabaseRequires(Object):
-    """Requires-side of the database relation."""
-
-    on = DatabaseEvents()
-
-    def __init__(
-        self, charm, relation_name: str, database_name: str, extra_user_roles: str = None
-    ):
-        """Manager of database client relations."""
-        super().__init__(charm, relation_name)
-        self.charm = charm
-        self.database = database_name
-        self.extra_user_roles = extra_user_roles
-        self.relation = self.charm.model.get_relation(relation_name)
-        self.framework.observe(
-            self.charm.on[relation_name].relation_joined, self._on_relation_joined_event
-        )
-        self.framework.observe(
-            self.charm.on[relation_name].relation_changed, self._on_relation_changed_event
-        )
-
-    def _diff(self, event: RelationChangedEvent) -> Diff:
-        """Retrieves the diff of the data in the relation changed databag.
-
-        Args:
-            event: relation changed event.
-
-        Returns:
-            a Diff instance containing the added, deleted and changed
-                keys from the event relation databag.
-        """
-        # Retrieve the old data from the data key in the application relation databag.
-        old_data = json.loads(self.relation.data[self.charm.model.app].get("data", "{}"))
-        # Retrieve the new data from the event relation databag.
-        new_data = event.relation.data[event.app]
-
-        # These are the keys that were added to the databag and triggered this event.
-        added = new_data.keys() - old_data.keys()
-        # These are the keys that were removed from the databag and triggered this event.
-        deleted = old_data.keys() - new_data.keys()
-        # These are the keys that already existed in the databag,
-        # but had their values changed.
-        changed = {
-            key for key in old_data.keys() & new_data.keys() if old_data[key] != new_data[key]
-        }
-
-        # TODO: evaluate the possibility of losing the diff if some error
-        # happens in the charm before the diff is completely checked (DPE-412).
-        # Convert the new_data to a serializable format and save it for a next diff check.
-        data = {key: value for key, value in new_data.items() if key != "data"}
-        self._update_relation_data({"data": json.dumps(data)})
-
-        # Return the diff with all possible changes.
-        return Diff(added, changed, deleted)
-
-    def _get_relation_data(self, key: str) -> Optional[str]:
+    def _get_relation_data(self, key: str, use_local_databag: bool = False) -> Optional[str]:
         """Retrieves data from relation.
 
         Args:
             key: key to retrieve the data from the relation.
+            use_local_databag: whether to retrieve the data from
+                the local application databag instead of from the
+                remote application databag.
 
         Returns:
-            a string value stored in the relation data bag for
+            value stored in the relation data bag for
                 the specified key or None if the key doesn't exist.
         """
-        return self.relation.data[self.relation.app].get(key)
+        app = self.local_app if use_local_databag else self.relation.app
+        return self.relation.data[app].get(key)
+
+    def _update_relation_data(self, data: dict) -> None:
+        """Updates a set of key-value pairs in the relation.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            data: dict containing the key-value pairs
+                that should be updated in the relation.
+        """
+        self.relation.data[self.local_app].update(data)
 
     @property
     def endpoints(self) -> Optional[str]:
@@ -228,19 +186,147 @@ class DatabaseRequires(Object):
         """
         return self._get_relation_data("version")
 
-    def _on_relation_joined_event(self, _) -> None:
+
+class DatabaseCreatedEvent(DatabaseEvent):
+    """Event emitted when a new database is created for use on this relation."""
+
+
+class DatabaseEndpointsChangedEvent(DatabaseEvent):
+    """Event emitted when the read/write endpoints are changed."""
+
+
+class DatabaseReadOnlyEndpointsChangedEvent(DatabaseEvent):
+    """Event emitted when the read only endpoints are changed."""
+
+
+class DatabaseEvents(CharmEvents):
+    """Database events.
+
+    This class defines the events that the database can emit.
+    """
+
+    database_created = EventSource(DatabaseCreatedEvent)
+    endpoints_changed = EventSource(DatabaseEndpointsChangedEvent)
+    read_only_endpoints_changed = EventSource(DatabaseReadOnlyEndpointsChangedEvent)
+
+
+Diff = namedtuple("Diff", "added changed deleted")
+Diff.__doc__ = """
+A tuple for storing the diff between two data mappings.
+
+added - keys that were added
+changed - keys that still exist but have new values
+deleted - key that were deleted"""
+
+
+class DatabaseRequires(Object):
+    """Requires-side of the database relation."""
+
+    on = DatabaseEvents()
+
+    def __init__(
+        self,
+        charm,
+        relation_name: str,
+        database_name: str,
+        extra_user_roles: str = None,
+    ):
+        """Manager of database client relations."""
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.database = database_name
+        self.extra_user_roles = extra_user_roles
+        self.local_app = self.charm.model.app
+        self.local_unit = self.charm.unit
+        self.relation_name = relation_name
+        self.framework.observe(
+            self.charm.on[relation_name].relation_joined, self._on_relation_joined_event
+        )
+        self.framework.observe(
+            self.charm.on[relation_name].relation_changed, self._on_relation_changed_event
+        )
+
+    def _diff(self, event: RelationChangedEvent) -> Diff:
+        """Retrieves the diff of the data in the relation changed databag.
+
+        Args:
+            event: relation changed event.
+
+        Returns:
+            a Diff instance containing the added, deleted and changed
+                keys from the event relation databag.
+        """
+        # Retrieve the old data from the data key in the application relation databag.
+        old_data = json.loads(event.relation.data[self.charm.model.app].get("data", "{}"))
+        # Retrieve the new data from the event relation databag.
+        new_data = {
+            key: value for key, value in event.relation.data[event.app].items() if key != "data"
+        }
+
+        # These are the keys that were added to the databag and triggered this event.
+        added = new_data.keys() - old_data.keys()
+        # These are the keys that were removed from the databag and triggered this event.
+        deleted = old_data.keys() - new_data.keys()
+        # These are the keys that already existed in the databag,
+        # but had their values changed.
+        changed = {
+            key for key in old_data.keys() & new_data.keys() if old_data[key] != new_data[key]
+        }
+
+        # TODO: evaluate the possibility of losing the diff if some error
+        # happens in the charm before the diff is completely checked (DPE-412).
+        # Convert the new_data to a serializable format and save it for a next diff check.
+        event.relation.data[self.local_app].update({"data": json.dumps(new_data)})
+
+        # Return the diff with all possible changes.
+        return Diff(added, changed, deleted)
+
+    def fetch_relation_data(self) -> dict:
+        """Retrieves data from relation.
+
+        This function can be used to retrieve data from a relation
+        in the charm code when outside an event callback.
+
+        Returns:
+            a dict of the values stored in the relation data bag
+                for all relation instances (indexed by the relation id).
+        """
+        data = {}
+        for relation in self.relations:
+            data[relation.id] = {
+                key: value for key, value in relation.data[relation.app].items() if key != "data"
+            }
+        return data
+
+    def _update_relation_data(self, relation_id: int, data: dict) -> None:
+        """Updates a set of key-value pairs in the relation.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            data: dict containing the key-value pairs
+                that should be updated in the relation.
+        """
+        if self.local_unit.is_leader():
+            relation = self.charm.model.get_relation(self.relation_name, relation_id)
+            relation.data[self.local_app].update(data)
+
+    def _on_relation_joined_event(self, event: RelationJoinedEvent) -> None:
         """Event emitted when the application joins the database relation."""
         # Sets both database and extra user roles in the relation
         # if the roles are provided. Otherwise, sets only the database.
         if self.extra_user_roles:
             self._update_relation_data(
+                event.relation.id,
                 {
                     "database": self.database,
                     "extra-user-roles": self.extra_user_roles,
-                }
+                },
             )
         else:
-            self._update_relation_data({"database": self.database})
+            self._update_relation_data(event.relation.id, {"database": self.database})
 
     def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
         """Event emitted when the database relation has changed."""
@@ -254,29 +340,21 @@ class DatabaseRequires(Object):
         # Check if the database is created
         # (the database charm shared the credentials).
         if "username" in diff.added and "password" in diff.added:
-            self.on.database_created.emit(event.relation)
+            self.on.database_created.emit(event.relation, self.local_app)
 
         # Emit an endpoints changed event if the database
         # added or changed this info in the relation databag.
         if "endpoints" in diff.added or "endpoints" in diff.changed:
             logger.info(f"endpoints changed on {datetime.now()}")
-            self.on.endpoints_changed.emit(event.relation)
+            self.on.endpoints_changed.emit(event.relation, self.local_app)
 
         # Emit a read only endpoints changed event if the database
         # added or changed this info in the relation databag.
         if "read-only-endpoints" in diff.added or "read-only-endpoints" in diff.changed:
             logger.info(f"read-only-endpoints changed on {datetime.now()}")
-            self.on.read_only_endpoints_changed.emit(event.relation)
+            self.on.read_only_endpoints_changed.emit(event.relation, self.local_app)
 
-    def _update_relation_data(self, data: dict) -> None:
-        """Updates a set of key-value pairs in the relation.
-
-        This function writes in the application data bag, therefore,
-        only the leader unit can call it.
-
-        Args:
-            data: dict containing the key-value pairs
-                that should be updated in the relation.
-        """
-        if self.charm.unit.is_leader():
-            self.relation.data[self.charm.model.app].update(data)
+    @property
+    def relations(self) -> List[Relation]:
+        """The list of Relation instances associated with this relation_name."""
+        return list(self.charm.model.relations[self.relation_name])

--- a/tests/integration/application-charm/src/charm.py
+++ b/tests/integration/application-charm/src/charm.py
@@ -10,7 +10,11 @@ of the libraries in this repository.
 
 import logging
 
-from charms.data_platform_libs.v0.database_requires import DatabaseRequires
+from charms.data_platform_libs.v0.database_requires import (
+    DatabaseCreatedEvent,
+    DatabaseEndpointsChangedEvent,
+    DatabaseRequires,
+)
 from ops.charm import CharmBase
 from ops.main import main
 from ops.model import ActiveStatus
@@ -41,17 +45,16 @@ class ApplicationCharm(CharmBase):
         """Only sets an Active status."""
         self.unit.status = ActiveStatus()
 
-    def _on_database_created(self, _) -> None:
+    # First database events.
+    def _on_database_created(self, event: DatabaseCreatedEvent) -> None:
         """Event triggered when a database was created for this application."""
         # Retrieve the credentials using the charm library.
-        logger.info(
-            f"_on_database_created called: {self.database.username} {self.database.password}"
-        )
+        logger.info(f"_on_database_created called: {event.username} {event.password}")
         self.unit.status = ActiveStatus("received database credentials")
 
-    def _on_endpoints_changed(self, _) -> None:
+    def _on_endpoints_changed(self, event: DatabaseEndpointsChangedEvent) -> None:
         """Event triggered when the read/write endpoints of the database change."""
-        logger.info(f"_on_endpoints_changed called: {self.database.endpoints}")
+        logger.info(f"_on_endpoints_changed called: {event.endpoints}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Issue
In short this PR partially address JIRA ticket [DPE-423](https://warthogs.atlassian.net/browse/DPE-423).

In long:
* Application charms using the requires charm library should be able to connect to multiple database clusters through the same relation.
* Currently, the library can't handle this situation. It faces some errors if we try to connect multiple clusters to the same relation because it doesn't provide a relation id (the id that differentiates the connections being made to the same relation in the database charm) when interacting with each different database cluster.

# Solution
* Use the relation id property from the relation linked to the custom events that are triggered inside the library.
* With the relation id it's possible to know which database cluster the application is talking to at a specific moment and get the relation data specific to that cluster.

# Context
* The documentation in the top of the library and also the database test charm were updated with the correct way to handle the relation data from one or multiple applications.
* The properties from the `DatabaseRequires` class  were moved to the `DatabaseEvent` class, which is a superclass for the custom events of this library. This is responsible for the big diff in the `DatabaseEvent` class.
* The functions from the `DatabaseRequires` class now use the relation id to correctly emit events from each different cluster.
* In the `DatabaseRequires` class, there is a new function called `fetch_relation_data` to make it still be possible to retrieve the data from the relation when outside an event callback like `_on_database_created`.
* **In summary, this PR addresses part of the implementation needed for the library to be able to connect to multiple database clusters. The remaining implementation will be done in the next PR (to avoid a bigger PR).**

# Testing
* Unit tests were updated and some new tests (related to setting data using the event object, which is now used to set data in the right relation instance) were implemented.
* Integration tests were not updated yet as there is some more code that needs to be implemented in the next PR.

# Release Notes
* Add code needed for later implementation about connecting to multiple database clusters through the same relation using the requires charm library.