### PR TITLE
Update tester charm and add test for multiple databases requests

### DIFF
--- a/tests/integration/application-charm/metadata.yaml
+++ b/tests/integration/application-charm/metadata.yaml
@@ -8,7 +8,5 @@ summary: |
   only for testing of the libs in this repository.
 
 requires:
-  first-database:
-    interface: database-client
-  second-database:
+  database:
     interface: database-client

--- a/tests/integration/application-charm/metadata.yaml
+++ b/tests/integration/application-charm/metadata.yaml
@@ -8,5 +8,7 @@ summary: |
   only for testing of the libs in this repository.
 
 requires:
-  database:
+  first-database:
+    interface: database-client
+  second-database:
     interface: database-client

--- a/tests/integration/application-charm/src/charm.py
+++ b/tests/integration/application-charm/src/charm.py
@@ -10,15 +10,17 @@ of the libraries in this repository.
 
 import logging
 
-from charms.data_platform_libs.v0.database_requires import DatabaseRequires
+from charms.data_platform_libs.v0.database_requires import (
+    DatabaseCreatedEvent,
+    DatabaseEndpointsChangedEvent,
+    DatabaseRequires,
+)
 from ops.charm import CharmBase
 from ops.main import main
 from ops.model import ActiveStatus
 
 logger = logging.getLogger(__name__)
 
-# Name of the database that this application requests to the database charm.
-DATABASE = "data_platform"
 # Extra roles that this application needs when interacting with the database.
 EXTRA_USER_ROLES = "CREATEDB,CREATEROLE"
 
@@ -32,26 +34,55 @@ class ApplicationCharm(CharmBase):
         # Default charm events.
         self.framework.observe(self.on.start, self._on_start)
 
-        # Charm events defined in the database requires charm library.
-        self.database = DatabaseRequires(self, "database", DATABASE, EXTRA_USER_ROLES)
-        self.framework.observe(self.database.on.database_created, self._on_database_created)
-        self.framework.observe(self.database.on.endpoints_changed, self._on_endpoints_changed)
+        # First database events (defined in the database requires charm library).
+        database_name = f'{self.app.name.replace("-", "_")}_first_database'
+        self.first_database = DatabaseRequires(
+            self, "first-database", database_name, EXTRA_USER_ROLES
+        )
+        self.framework.observe(
+            self.first_database.on.database_created, self._on_first_database_created
+        )
+        self.framework.observe(
+            self.first_database.on.endpoints_changed, self._on_first_database_endpoints_changed
+        )
+
+        # Second database events (defined in the database requires charm library).
+        database_name = f'{self.app.name.replace("-", "_")}_second_database'
+        self.second_database = DatabaseRequires(
+            self, "second-database", database_name, EXTRA_USER_ROLES
+        )
+        self.framework.observe(
+            self.second_database.on.database_created, self._on_second_database_created
+        )
+        self.framework.observe(
+            self.second_database.on.endpoints_changed, self._on_second_database_endpoints_changed
+        )
 
     def _on_start(self, _) -> None:
         """Only sets an Active status."""
         self.unit.status = ActiveStatus()
 
-    def _on_database_created(self, _) -> None:
+    # First database events.
+    def _on_first_database_created(self, event: DatabaseCreatedEvent) -> None:
         """Event triggered when a database was created for this application."""
         # Retrieve the credentials using the charm library.
-        logger.info(
-            f"_on_database_created called: {self.database.username} {self.database.password}"
-        )
-        self.unit.status = ActiveStatus("received database credentials")
+        logger.info(f"first database credentials: {event.username} {event.password}")
+        self.unit.status = ActiveStatus("received database credentials for first database")
 
-    def _on_endpoints_changed(self, _) -> None:
+    def _on_first_database_endpoints_changed(self, event: DatabaseEndpointsChangedEvent) -> None:
         """Event triggered when the read/write endpoints of the database change."""
-        logger.info(f"_on_endpoints_changed called: {self.database.endpoints}")
+        logger.info(f"first database endpoints have been changed to: {event.endpoints}")
+
+    # Second database events.
+    def _on_second_database_created(self, event: DatabaseCreatedEvent) -> None:
+        """Event triggered when a database was created for this application."""
+        # Retrieve the credentials using the charm library.
+        logger.info(f"second database credentials: {event.username} {event.password}")
+        self.unit.status = ActiveStatus("received database credentials for second database")
+
+    def _on_second_database_endpoints_changed(self, event: DatabaseEndpointsChangedEvent) -> None:
+        """Event triggered when the read/write endpoints of the database change."""
+        logger.info(f"second database endpoints have been changed to: {event.endpoints}")
 
 
 if __name__ == "__main__":

--- a/tests/integration/application-charm/src/charm.py
+++ b/tests/integration/application-charm/src/charm.py
@@ -34,27 +34,57 @@ class ApplicationCharm(CharmBase):
         # Default charm events.
         self.framework.observe(self.on.start, self._on_start)
 
-        # Name of the database that this application requests to the database charm.
-        database = f'data_platform_{self.app.name.replace("-", "_")}'
-        # Charm events defined in the database requires charm library.
-        self.database = DatabaseRequires(self, "database", database, EXTRA_USER_ROLES)
-        self.framework.observe(self.database.on.database_created, self._on_database_created)
-        self.framework.observe(self.database.on.endpoints_changed, self._on_endpoints_changed)
+        # Events related to the first database that is requested
+        # (these events are defined in the database requires charm library).
+        database_name = f'{self.app.name.replace("-", "_")}_first_database'
+        self.first_database = DatabaseRequires(
+            self, "first-database", database_name, EXTRA_USER_ROLES
+        )
+        self.framework.observe(
+            self.first_database.on.database_created, self._on_first_database_created
+        )
+        self.framework.observe(
+            self.first_database.on.endpoints_changed, self._on_first_database_endpoints_changed
+        )
+
+        # Events related to the second database that is requested
+        # (these events are defined in the database requires charm library).
+        database_name = f'{self.app.name.replace("-", "_")}_second_database'
+        self.second_database = DatabaseRequires(
+            self, "second-database", database_name, EXTRA_USER_ROLES
+        )
+        self.framework.observe(
+            self.second_database.on.database_created, self._on_second_database_created
+        )
+        self.framework.observe(
+            self.second_database.on.endpoints_changed, self._on_second_database_endpoints_changed
+        )
 
     def _on_start(self, _) -> None:
         """Only sets an Active status."""
         self.unit.status = ActiveStatus()
 
-    # First database events.
-    def _on_database_created(self, event: DatabaseCreatedEvent) -> None:
+    # First database events observers.
+    def _on_first_database_created(self, event: DatabaseCreatedEvent) -> None:
         """Event triggered when a database was created for this application."""
         # Retrieve the credentials using the charm library.
-        logger.info(f"_on_database_created called: {event.username} {event.password}")
-        self.unit.status = ActiveStatus("received database credentials")
+        logger.info(f"first database credentials: {event.username} {event.password}")
+        self.unit.status = ActiveStatus("received database credentials of the first database")
 
-    def _on_endpoints_changed(self, event: DatabaseEndpointsChangedEvent) -> None:
+    def _on_first_database_endpoints_changed(self, event: DatabaseEndpointsChangedEvent) -> None:
         """Event triggered when the read/write endpoints of the database change."""
-        logger.info(f"_on_endpoints_changed called: {event.endpoints}")
+        logger.info(f"first database endpoints have been changed to: {event.endpoints}")
+
+    # Second database events observers.
+    def _on_second_database_created(self, event: DatabaseCreatedEvent) -> None:
+        """Event triggered when a database was created for this application."""
+        # Retrieve the credentials using the charm library.
+        logger.info(f"second database credentials: {event.username} {event.password}")
+        self.unit.status = ActiveStatus("received database credentials of the second database")
+
+    def _on_second_database_endpoints_changed(self, event: DatabaseEndpointsChangedEvent) -> None:
+        """Event triggered when the read/write endpoints of the database change."""
+        logger.info(f"second database endpoints have been changed to: {event.endpoints}")
 
 
 if __name__ == "__main__":

--- a/tests/integration/application-charm/src/charm.py
+++ b/tests/integration/application-charm/src/charm.py
@@ -34,55 +34,27 @@ class ApplicationCharm(CharmBase):
         # Default charm events.
         self.framework.observe(self.on.start, self._on_start)
 
-        # First database events (defined in the database requires charm library).
-        database_name = f'{self.app.name.replace("-", "_")}_first_database'
-        self.first_database = DatabaseRequires(
-            self, "first-database", database_name, EXTRA_USER_ROLES
-        )
-        self.framework.observe(
-            self.first_database.on.database_created, self._on_first_database_created
-        )
-        self.framework.observe(
-            self.first_database.on.endpoints_changed, self._on_first_database_endpoints_changed
-        )
-
-        # Second database events (defined in the database requires charm library).
-        database_name = f'{self.app.name.replace("-", "_")}_second_database'
-        self.second_database = DatabaseRequires(
-            self, "second-database", database_name, EXTRA_USER_ROLES
-        )
-        self.framework.observe(
-            self.second_database.on.database_created, self._on_second_database_created
-        )
-        self.framework.observe(
-            self.second_database.on.endpoints_changed, self._on_second_database_endpoints_changed
-        )
+        # Name of the database that this application requests to the database charm.
+        database = f'data_platform_{self.app.name.replace("-", "_")}'
+        # Charm events defined in the database requires charm library.
+        self.database = DatabaseRequires(self, "database", database, EXTRA_USER_ROLES)
+        self.framework.observe(self.database.on.database_created, self._on_database_created)
+        self.framework.observe(self.database.on.endpoints_changed, self._on_endpoints_changed)
 
     def _on_start(self, _) -> None:
         """Only sets an Active status."""
         self.unit.status = ActiveStatus()
 
     # First database events.
-    def _on_first_database_created(self, event: DatabaseCreatedEvent) -> None:
+    def _on_database_created(self, event: DatabaseCreatedEvent) -> None:
         """Event triggered when a database was created for this application."""
         # Retrieve the credentials using the charm library.
-        logger.info(f"first database credentials: {event.username} {event.password}")
-        self.unit.status = ActiveStatus("received database credentials for first database")
+        logger.info(f"_on_database_created called: {event.username} {event.password}")
+        self.unit.status = ActiveStatus("received database credentials")
 
-    def _on_first_database_endpoints_changed(self, event: DatabaseEndpointsChangedEvent) -> None:
+    def _on_endpoints_changed(self, event: DatabaseEndpointsChangedEvent) -> None:
         """Event triggered when the read/write endpoints of the database change."""
-        logger.info(f"first database endpoints have been changed to: {event.endpoints}")
-
-    # Second database events.
-    def _on_second_database_created(self, event: DatabaseCreatedEvent) -> None:
-        """Event triggered when a database was created for this application."""
-        # Retrieve the credentials using the charm library.
-        logger.info(f"second database credentials: {event.username} {event.password}")
-        self.unit.status = ActiveStatus("received database credentials for second database")
-
-    def _on_second_database_endpoints_changed(self, event: DatabaseEndpointsChangedEvent) -> None:
-        """Event triggered when the read/write endpoints of the database change."""
-        logger.info(f"second database endpoints have been changed to: {event.endpoints}")
+        logger.info(f"_on_endpoints_changed called: {event.endpoints}")
 
 
 if __name__ == "__main__":

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -7,34 +7,48 @@ import yaml
 from pytest_operator.plugin import OpsTest
 
 
-async def build_connection_string(ops_test: OpsTest, application_name: str) -> str:
+async def build_connection_string(
+    ops_test: OpsTest, application_name: str, relation_name: str
+) -> str:
     """Build a PostgreSQL connection string.
 
     Args:
         ops_test: The ops test framework instance
         application_name: The name of the application
+        relation_name: name of the relation to get connection data from
 
     Returns:
         a PostgreSQL connection string
     """
     # Get the connection data exposed to the application through the relation.
-    username = await get_application_relation_data(ops_test, application_name, "username")
-    password = await get_application_relation_data(ops_test, application_name, "password")
-    endpoints = await get_application_relation_data(ops_test, application_name, "endpoints")
+    database = f'{application_name.replace("-", "_")}_{relation_name.replace("-", "_")}'
+    username = await get_application_relation_data(
+        ops_test, application_name, relation_name, "username"
+    )
+    password = await get_application_relation_data(
+        ops_test, application_name, relation_name, "password"
+    )
+    endpoints = await get_application_relation_data(
+        ops_test, application_name, relation_name, "endpoints"
+    )
     host = endpoints.split(",")[0].split(":")[0]
 
     # Build the complete connection string to connect to the database.
-    return f"dbname='data_platform' user='{username}' host='{host}' password='{password}' connect_timeout=10"
+    return f"dbname='{database}' user='{username}' host='{host}' password='{password}' connect_timeout=10"
 
 
 async def get_application_relation_data(
-    ops_test: OpsTest, application_name: str, key: str
+    ops_test: OpsTest,
+    application_name: str,
+    relation_name: str,
+    key: str,
 ) -> Optional[str]:
     """Get relation data for an application.
 
     Args:
         ops_test: The ops test framework instance
         application_name: The name of the application
+        relation_name: name of the relation to get connection data from
         key: key of data to be retrieved
 
     Returns:
@@ -42,11 +56,17 @@ async def get_application_relation_data(
             if no data in the relation
 
     Raises:
-        ValueError if it's not possible to get application unit data.
+        ValueError if it's not possible to get application unit data
+            or if there is no data for the particular relation endpoint.
     """
     unit_name = f"{application_name}/0"
     raw_data = (await ops_test.juju("show-unit", unit_name))[1]
     if not raw_data:
         raise ValueError(f"no unit info could be grabbed for {unit_name}")
     data = yaml.safe_load(raw_data)
-    return data[unit_name]["relation-info"][0]["application-data"].get(key)
+    relation_data = [v for v in data[unit_name]["relation-info"] if v["endpoint"] == relation_name]
+    if len(relation_data) == 0:
+        raise ValueError(
+            f"no relation data could be grabbed on relation with endpoint {relation_name}"
+        )
+    return relation_data[0]["application-data"].get(key)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -7,30 +7,21 @@ import yaml
 from pytest_operator.plugin import OpsTest
 
 
-async def build_connection_string(
-    ops_test: OpsTest, application_name: str, relation_name: str
-) -> str:
+async def build_connection_string(ops_test: OpsTest, application_name: str) -> str:
     """Build a PostgreSQL connection string.
 
     Args:
         ops_test: The ops test framework instance
         application_name: The name of the application
-        relation_name: name of the relation to get connection data from
 
     Returns:
         a PostgreSQL connection string
     """
     # Get the connection data exposed to the application through the relation.
-    database = f'{application_name.replace("-", "_")}_{relation_name.replace("-", "_")}'
-    username = await get_application_relation_data(
-        ops_test, application_name, relation_name, "username"
-    )
-    password = await get_application_relation_data(
-        ops_test, application_name, relation_name, "password"
-    )
-    endpoints = await get_application_relation_data(
-        ops_test, application_name, relation_name, "endpoints"
-    )
+    database = f'data_platform_{application_name.replace("-", "_")}'
+    username = await get_application_relation_data(ops_test, application_name, "username")
+    password = await get_application_relation_data(ops_test, application_name, "password")
+    endpoints = await get_application_relation_data(ops_test, application_name, "endpoints")
     host = endpoints.split(",")[0].split(":")[0]
 
     # Build the complete connection string to connect to the database.
@@ -38,17 +29,13 @@ async def build_connection_string(
 
 
 async def get_application_relation_data(
-    ops_test: OpsTest,
-    application_name: str,
-    relation_name: str,
-    key: str,
+    ops_test: OpsTest, application_name: str, key: str
 ) -> Optional[str]:
     """Get relation data for an application.
 
     Args:
         ops_test: The ops test framework instance
         application_name: The name of the application
-        relation_name: name of the relation to get connection data from
         key: key of data to be retrieved
 
     Returns:
@@ -56,17 +43,11 @@ async def get_application_relation_data(
             if no data in the relation
 
     Raises:
-        ValueError if it's not possible to get application unit data
-            or if there is no data for the particular relation endpoint.
+        ValueError if it's not possible to get application unit data.
     """
     unit_name = f"{application_name}/0"
     raw_data = (await ops_test.juju("show-unit", unit_name))[1]
     if not raw_data:
         raise ValueError(f"no unit info could be grabbed for {unit_name}")
     data = yaml.safe_load(raw_data)
-    relation_data = [v for v in data[unit_name]["relation-info"] if v["endpoint"] == relation_name]
-    if len(relation_data) == 0:
-        raise ValueError(
-            f"no relation data could be grabbed on relation with endpoint {relation_name}"
-        )
-    return relation_data[0]["application-data"].get(key)
+    return data[unit_name]["relation-info"][0]["application-data"].get(key)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -7,21 +7,30 @@ import yaml
 from pytest_operator.plugin import OpsTest
 
 
-async def build_connection_string(ops_test: OpsTest, application_name: str) -> str:
+async def build_connection_string(
+    ops_test: OpsTest, application_name: str, relation_name: str
+) -> str:
     """Build a PostgreSQL connection string.
 
     Args:
         ops_test: The ops test framework instance
         application_name: The name of the application
+        relation_name: name of the relation to get connection data from
 
     Returns:
         a PostgreSQL connection string
     """
     # Get the connection data exposed to the application through the relation.
-    database = f'data_platform_{application_name.replace("-", "_")}'
-    username = await get_application_relation_data(ops_test, application_name, "username")
-    password = await get_application_relation_data(ops_test, application_name, "password")
-    endpoints = await get_application_relation_data(ops_test, application_name, "endpoints")
+    database = f'{application_name.replace("-", "_")}_{relation_name.replace("-", "_")}'
+    username = await get_application_relation_data(
+        ops_test, application_name, relation_name, "username"
+    )
+    password = await get_application_relation_data(
+        ops_test, application_name, relation_name, "password"
+    )
+    endpoints = await get_application_relation_data(
+        ops_test, application_name, relation_name, "endpoints"
+    )
     host = endpoints.split(",")[0].split(":")[0]
 
     # Build the complete connection string to connect to the database.
@@ -29,13 +38,17 @@ async def build_connection_string(ops_test: OpsTest, application_name: str) -> s
 
 
 async def get_application_relation_data(
-    ops_test: OpsTest, application_name: str, key: str
+    ops_test: OpsTest,
+    application_name: str,
+    relation_name: str,
+    key: str,
 ) -> Optional[str]:
     """Get relation data for an application.
 
     Args:
         ops_test: The ops test framework instance
         application_name: The name of the application
+        relation_name: name of the relation to get connection data from
         key: key of data to be retrieved
 
     Returns:
@@ -43,11 +56,18 @@ async def get_application_relation_data(
             if no data in the relation
 
     Raises:
-        ValueError if it's not possible to get application unit data.
+        ValueError if it's not possible to get application unit data
+            or if there is no data for the particular relation endpoint.
     """
     unit_name = f"{application_name}/0"
     raw_data = (await ops_test.juju("show-unit", unit_name))[1]
     if not raw_data:
         raise ValueError(f"no unit info could be grabbed for {unit_name}")
     data = yaml.safe_load(raw_data)
-    return data[unit_name]["relation-info"][0]["application-data"].get(key)
+    # Filter the data based on the relation name.
+    relation_data = [v for v in data[unit_name]["relation-info"] if v["endpoint"] == relation_name]
+    if len(relation_data) == 0:
+        raise ValueError(
+            f"no relation data could be grabbed on relation with endpoint {relation_name}"
+        )
+    return relation_data[0]["application-data"].get(key)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -23,6 +23,8 @@ APP_NAMES = [APPLICATION_APP_NAME, DATABASE_APP_NAME]
 DATABASE_APP_METADATA = yaml.safe_load(
     Path("./tests/integration/database-charm/metadata.yaml").read_text()
 )
+FIRST_DATABASE_RELATION_NAME = "first-database"
+SECOND_DATABASE_RELATION_NAME = "second-database"
 
 
 @pytest.mark.abort_on_fail
@@ -54,11 +56,15 @@ async def test_deploy_charms(ops_test: OpsTest, application_charm, database_char
 async def test_database_relation_with_charm_libraries(ops_test: OpsTest):
     """Test basic functionality of database relation interface."""
     # Relate the charms and wait for them exchanging some connection data.
-    await ops_test.model.add_relation(APPLICATION_APP_NAME, DATABASE_APP_NAME)
+    await ops_test.model.add_relation(
+        f"{APPLICATION_APP_NAME}:{FIRST_DATABASE_RELATION_NAME}", DATABASE_APP_NAME
+    )
     await ops_test.model.wait_for_idle(apps=APP_NAMES, status="active")
 
     # Get the connection string to connect to the database.
-    connection_string = await build_connection_string(ops_test, APPLICATION_APP_NAME)
+    connection_string = await build_connection_string(
+        ops_test, APPLICATION_APP_NAME, FIRST_DATABASE_RELATION_NAME
+    )
 
     # Connect to the database.
     with psycopg2.connect(connection_string) as connection, connection.cursor() as cursor:
@@ -78,14 +84,18 @@ async def test_database_relation_with_charm_libraries(ops_test: OpsTest):
 
         # Get the version of the database and compare with the information that
         # was retrieved directly from the database.
-        version = await get_application_relation_data(ops_test, APPLICATION_APP_NAME, "version")
+        version = await get_application_relation_data(
+            ops_test, APPLICATION_APP_NAME, FIRST_DATABASE_RELATION_NAME, "version"
+        )
         assert version == data[0]
 
 
 async def test_user_with_extra_roles(ops_test: OpsTest):
     """Test superuser actions and the request for more permissions."""
     # Get the connection string to connect to the database.
-    connection_string = await build_connection_string(ops_test, APPLICATION_APP_NAME)
+    connection_string = await build_connection_string(
+        ops_test, APPLICATION_APP_NAME, FIRST_DATABASE_RELATION_NAME
+    )
 
     # Connect to the database.
     connection = psycopg2.connect(connection_string)
@@ -118,12 +128,36 @@ async def test_two_applications_doesnt_share_the_same_relation_data(
 
     # Relate the new application with the database
     # and wait for them exchanging some connection data.
-    await ops_test.model.add_relation(another_application_app_name, DATABASE_APP_NAME)
+    await ops_test.model.add_relation(
+        f"{another_application_app_name}:{FIRST_DATABASE_RELATION_NAME}", DATABASE_APP_NAME
+    )
     await ops_test.model.wait_for_idle(apps=all_app_names, status="active")
 
     # Assert the two application have different relation (connection) data.
-    application_connection_string = await build_connection_string(ops_test, APPLICATION_APP_NAME)
+    application_connection_string = await build_connection_string(
+        ops_test, APPLICATION_APP_NAME, FIRST_DATABASE_RELATION_NAME
+    )
     another_application_connection_string = await build_connection_string(
-        ops_test, another_application_app_name
+        ops_test, another_application_app_name, FIRST_DATABASE_RELATION_NAME
     )
     assert application_connection_string != another_application_connection_string
+
+
+async def test_an_application_can_request_multiple_databases(ops_test: OpsTest, application_charm):
+    """Test that an application can request additional databases using the same interface."""
+    # Relate the charms using another relation and wait for them exchanging some connection data.
+    await ops_test.model.add_relation(
+        f"{APPLICATION_APP_NAME}:{SECOND_DATABASE_RELATION_NAME}", DATABASE_APP_NAME
+    )
+    await ops_test.model.wait_for_idle(apps=APP_NAMES, status="active")
+
+    # Get the connection strings to connect to both databases.
+    first_database_connection_string = await build_connection_string(
+        ops_test, APPLICATION_APP_NAME, FIRST_DATABASE_RELATION_NAME
+    )
+    second_database_connection_string = await build_connection_string(
+        ops_test, APPLICATION_APP_NAME, SECOND_DATABASE_RELATION_NAME
+    )
+
+    # Assert the two application have different relation (connection) data.
+    assert first_database_connection_string != second_database_connection_string

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -23,8 +23,6 @@ APP_NAMES = [APPLICATION_APP_NAME, DATABASE_APP_NAME]
 DATABASE_APP_METADATA = yaml.safe_load(
     Path("./tests/integration/database-charm/metadata.yaml").read_text()
 )
-FIRST_DATABASE_RELATION_NAME = "first-database"
-SECOND_DATABASE_RELATION_NAME = "second-database"
 
 
 @pytest.mark.abort_on_fail
@@ -56,15 +54,11 @@ async def test_deploy_charms(ops_test: OpsTest, application_charm, database_char
 async def test_database_relation_with_charm_libraries(ops_test: OpsTest):
     """Test basic functionality of database relation interface."""
     # Relate the charms and wait for them exchanging some connection data.
-    await ops_test.model.add_relation(
-        f"{APPLICATION_APP_NAME}:{FIRST_DATABASE_RELATION_NAME}", DATABASE_APP_NAME
-    )
+    await ops_test.model.add_relation(APPLICATION_APP_NAME, DATABASE_APP_NAME)
     await ops_test.model.wait_for_idle(apps=APP_NAMES, status="active")
 
     # Get the connection string to connect to the database.
-    connection_string = await build_connection_string(
-        ops_test, APPLICATION_APP_NAME, FIRST_DATABASE_RELATION_NAME
-    )
+    connection_string = await build_connection_string(ops_test, APPLICATION_APP_NAME)
 
     # Connect to the database.
     with psycopg2.connect(connection_string) as connection, connection.cursor() as cursor:
@@ -84,18 +78,14 @@ async def test_database_relation_with_charm_libraries(ops_test: OpsTest):
 
         # Get the version of the database and compare with the information that
         # was retrieved directly from the database.
-        version = await get_application_relation_data(
-            ops_test, APPLICATION_APP_NAME, FIRST_DATABASE_RELATION_NAME, "version"
-        )
+        version = await get_application_relation_data(ops_test, APPLICATION_APP_NAME, "version")
         assert version == data[0]
 
 
 async def test_user_with_extra_roles(ops_test: OpsTest):
     """Test superuser actions and the request for more permissions."""
     # Get the connection string to connect to the database.
-    connection_string = await build_connection_string(
-        ops_test, APPLICATION_APP_NAME, FIRST_DATABASE_RELATION_NAME
-    )
+    connection_string = await build_connection_string(ops_test, APPLICATION_APP_NAME)
 
     # Connect to the database.
     connection = psycopg2.connect(connection_string)
@@ -137,22 +127,3 @@ async def test_two_applications_doesnt_share_the_same_relation_data(
         ops_test, another_application_app_name
     )
     assert application_connection_string != another_application_connection_string
-
-async def test_an_application_can_request_multiple_databases(ops_test: OpsTest, application_charm):
-    """Test that an application can request additional databases using the same interface."""
-    # Relate the charms using another relation and wait for them exchanging some connection data.
-    await ops_test.model.add_relation(
-        f"{APPLICATION_APP_NAME}:{SECOND_DATABASE_RELATION_NAME}", DATABASE_APP_NAME
-    )
-    await ops_test.model.wait_for_idle(apps=APP_NAMES, status="active")
-
-    # Get the connection strings to connect to both databases.
-    first_database_connection_string = await build_connection_string(
-        ops_test, APPLICATION_APP_NAME, FIRST_DATABASE_RELATION_NAME
-    )
-    second_database_connection_string = await build_connection_string(
-        ops_test, APPLICATION_APP_NAME, SECOND_DATABASE_RELATION_NAME
-    )
-
-    # Assert the two application have different relation (connection) data.
-    assert first_database_connection_string != second_database_connection_string


### PR DESCRIPTION
# Issue
In short this PR address JIRA ticket [DPE-422](https://warthogs.atlassian.net/browse/DPE-422).

In long:
* Database charms using the requires charm library should be able to request multiple databases to the same database charm.
* Currently, this is something that isn't being tested.

# Solution
* Add an integration test that ensures that the requires charm library can request multiple databases to the same database charm.

# Context
* Multiple relations are needed to accomplish that, because we can't relate twice the same application and database using the same relation name.
* Some updates were made in the `tests/integration/helpers.py`and `tests/integration/test_charm.py` files to handle .

# Testing
* Unit tests were not updated on this PR as there wasn't any update in the libraries code.
* One more integration test was added to cover the case of two databases being requested by the application to the same database charm.
* Some updates were made in the integration tests to use some constants related to the relation names.

# Release Notes
* Ensure that is possible to request multiple databases to the same database charm using the requires charm library.