### PR TITLE
Improve documementation

### DIFF
--- a/lib/charms/data_platform_libs/v0/database_provides.py
+++ b/lib/charms/data_platform_libs/v0/database_provides.py
@@ -18,6 +18,10 @@ This library is a uniform interface to a selection of common database
 metadata, with added custom events that add convenience to database management,
 and methods to set the application related data.
 
+It can be used as the main library in a database charm to handle relations with
+application charms or be extended/used as a template when creating a more complete library
+(like one that also handles the database and user creation using database specific APIs).
+
 Following an example of using the DatabaseRequestedEvent, in the context of the
 database charm code:
 

--- a/lib/charms/data_platform_libs/v0/database_provides.py
+++ b/lib/charms/data_platform_libs/v0/database_provides.py
@@ -52,6 +52,12 @@ class SampleCharm(CharmBase):
 
         # set other variables for the relation event.set_tls("False")
 ```
+
+As shown above, the library provides a custom event (database_requested) to handle
+the situation when an application charm requests a new database to be created.
+It's preferred to subscribe to this event instead of relation changed event to avoid
+creating a new database when other information other than a database name is
+exchanged in the relation databag.
 """
 import json
 import logging

--- a/lib/charms/data_platform_libs/v0/database_requires.py
+++ b/lib/charms/data_platform_libs/v0/database_requires.py
@@ -52,6 +52,14 @@ class ApplicationCharm(CharmBase):
         self.unit.status = ActiveStatus("received database credentials")
 ```
 
+As shown above, the library provides some custom events to handle specific situations,
+which are listed below:
+
+- database_created: event emitted when the requested database was created
+- endpoints_changed: event emitted when the read/write endpoints of the database have changed
+- read_only_endpoints_changed: event emitted when the read-only endpoints of the database
+  have changed
+
 If it's needed to connect multiple database clusters to the same relation endpoint
 it's possible to provide or not aliases for the different clusters/relations.
 


### PR DESCRIPTION
# Issue
In short this PR address JIRA ticket [DPE-460](https://warthogs.atlassian.net/browse/DPE-460).

In long:
* The current requires charm library doesn't document how to use cluster aliases and how to differentiate multiple clusters in the library header.
* Both libraries doesn't explain the available custom events in the header documentation.
* Also, sometime the provides charm library generates some confusion when a database charm already has a provides library.

# Solution
* Add some more details and examples (in the case of the cluster aliases) in the libraries header documentation.

# Context
* For the third item mentioned in the issue section, MongoDB, for example, has its own [provides charm library](https://github.com/canonical/mongodb-operator/blob/main/lib/charms/mongodb_libs/v0/mongodb_provider.py), which also handles the creation of database and users.

# Testing
* No new tests are needed as what has changed was only documentation.

# Release Notes
* Add documentation about connecting to multiple clusters
* Add documentation about custom events
* Document the possibility about using the provides charm library as a template for more complete libraries