### PR TITLE
Add placeholder charm to enable libraries on Chamhub pages

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,0 +1,8 @@
+type: "charm"
+bases:
+  - build-on:
+    - name: "ubuntu"
+      channel: "20.04"
+    run-on:
+    - name: "ubuntu"
+      channel: "20.04"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ show_missing = true
 [tool.pytest.ini_options]
 minversion = "6.0"
 log_cli_level = "INFO"
+asyncio_mode = "auto"
 
 # Formatting tools configuration
 [tool.black]

--- a/src/charm.py
+++ b/src/charm.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -1,0 +1,15 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""A placeholder charm for the Data Platform libs."""
+
+from ops.charm import CharmBase
+from ops.main import main
+
+
+class DataPlatformLibsCharm(CharmBase):
+    """Placeholder charm for Data Platform libs."""
+
+
+if __name__ == "__main__":
+    main(DataPlatformLibsCharm)

--- a/tox.ini
+++ b/tox.ini
@@ -7,13 +7,14 @@ skip_missing_interpreters = True
 envlist = lint, unit
 
 [vars]
+src_path = {toxinidir}/src/
 tst_path = {toxinidir}/tests/
 lib_path = {toxinidir}/lib/charms/data_platform_libs
-all_path = {[vars]tst_path} {[vars]lib_path}
+all_path = {[vars]src_path} {[vars]tst_path} {[vars]lib_path}
 
 [testenv]
 setenv =
-  PYTHONPATH = {toxinidir}:{toxinidir}/lib
+  PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
   PYTHONBREAKPOINT=ipdb.set_trace
   PY_COLORS=1
 passenv =
@@ -59,7 +60,7 @@ deps =
     coverage[toml]
     -r{toxinidir}/requirements.txt
 commands =
-    coverage run --source={[vars]lib_path} \
+    coverage run --source={[vars]src_path},{[vars]lib_path} \
         -m pytest --ignore={[vars]tst_path}integration -v --tb native -s {posargs}
     coverage report
 


### PR DESCRIPTION
# A very small PR

Add a simple placeholder charm (that was previously manually uploaded to charmhub to make available the pages showing the libraries).