### PR TITLE
Add app and unit information to events

### DIFF
--- a/lib/charms/data_platform_libs/v0/database_provides.py
+++ b/lib/charms/data_platform_libs/v0/database_provides.py
@@ -80,7 +80,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 logger = logging.getLogger(__name__)
 
@@ -184,7 +184,7 @@ class DatabaseProvides(Object):
         # Emit a database requested event if the setup key (database name and optional
         # extra user roles) was added to the relation databag by the application.
         if "database" in diff.added:
-            self.on.database_requested.emit(event.relation)
+            self.on.database_requested.emit(event.relation, app=event.app, unit=event.unit)
 
     def fetch_relation_data(self) -> dict:
         """Retrieves data from relation.

--- a/lib/charms/harness_extensions/v0/capture_events.py
+++ b/lib/charms/harness_extensions/v0/capture_events.py
@@ -1,0 +1,86 @@
+'''This is a library providing a utility for unittesting events fired on a
+Harness-ed Charm.
+
+Example usage:
+
+>>> from charms.harness_extensions.v0.capture_events import capture
+>>> with capture(RelationEvent) as captured:
+>>>     harness.add_relation('foo', 'remote')
+>>> assert captured.event.unit.name == 'remote'
+'''
+
+# The unique Charmhub library identifier, never change it
+LIBID = "9fcdab70e26d4eee9797c0e542ab397a"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 3
+
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from contextlib import contextmanager
+from typing import Generic, Iterator, Optional, Type, TypeVar
+
+from ops.charm import CharmBase
+from ops.framework import EventBase
+
+_T = TypeVar("_T", bound=EventBase)
+
+
+@contextmanager
+def capture_events(charm: CharmBase, *types: Type[EventBase]):
+    """Capture all events of type `*types` (using instance checks)."""
+    allowed_types = types or (EventBase,)
+
+    captured = []
+    _real_emit = charm.framework._emit
+
+    def _wrapped_emit(evt):
+        if isinstance(evt, allowed_types):
+            captured.append(evt)
+        return _real_emit(evt)
+
+    charm.framework._emit = _wrapped_emit  # type: ignore # noqa # ugly
+
+    yield captured
+
+    charm.framework._emit = _real_emit  # type: ignore # noqa # ugly
+
+
+class Captured(Generic[_T]):
+    """Object to type and expose return value of capture()."""
+
+    _event = None
+
+    @property
+    def event(self) -> Optional[_T]:
+        """Return the captured event."""
+        return self._event
+
+    @event.setter
+    def event(self, val: _T):
+        self._event = val
+
+
+@contextmanager
+def capture(charm: CharmBase, typ_: Type[_T] = EventBase) -> Iterator[Captured[_T]]:
+    """Capture exactly 1 event of type `typ_`.
+
+    Will raise if more/less events have been fired, or if the returned event
+    does not pass an instance check.
+    """
+    result = Captured()
+    with capture_events(charm, typ_) as captured:
+        if not captured:
+            yield result
+
+    assert len(captured) <= 1, f"too many events captured: {captured}"
+    assert len(captured) >= 1, f"no event of type {typ_} emitted."
+    event = captured[0]
+    assert isinstance(event, typ_), f"expected {typ_}, not {type(event)}"
+    result.event = event
+

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -164,6 +164,9 @@ async def test_an_application_can_connect_to_multiple_database_clusters(
     first_cluster_relation = await ops_test.model.add_relation(
         f"{APPLICATION_APP_NAME}:{MULTIPLE_DATABASE_CLUSTERS_RELATION_NAME}", DATABASE_APP_NAME
     )
+    # This call enables the unit to be available in the relation changed event.
+    await ops_test.model.wait_for_idle(apps=APP_NAMES, status="active")
+
     second_cluster_relation = await ops_test.model.add_relation(
         f"{APPLICATION_APP_NAME}:{MULTIPLE_DATABASE_CLUSTERS_RELATION_NAME}",
         ANOTHER_DATABASE_APP_NAME,
@@ -193,15 +196,16 @@ async def test_an_application_can_connect_to_multiple_aliased_database_clusters(
     """Test that an application can connect to different clusters of the same database."""
     # Relate the application with both database clusters
     # and wait for them exchanging some connection data.
-    await asyncio.gather(
-        ops_test.model.add_relation(
-            f"{APPLICATION_APP_NAME}:{ALIASED_MULTIPLE_DATABASE_CLUSTERS_RELATION_NAME}",
-            DATABASE_APP_NAME,
-        ),
-        ops_test.model.add_relation(
-            f"{APPLICATION_APP_NAME}:{ALIASED_MULTIPLE_DATABASE_CLUSTERS_RELATION_NAME}",
-            ANOTHER_DATABASE_APP_NAME,
-        ),
+    await ops_test.model.add_relation(
+        f"{APPLICATION_APP_NAME}:{ALIASED_MULTIPLE_DATABASE_CLUSTERS_RELATION_NAME}",
+        DATABASE_APP_NAME,
+    )
+    # This call enables the unit to be available in the relation changed event.
+    await ops_test.model.wait_for_idle(apps=APP_NAMES, status="active")
+
+    await ops_test.model.add_relation(
+        f"{APPLICATION_APP_NAME}:{ALIASED_MULTIPLE_DATABASE_CLUSTERS_RELATION_NAME}",
+        ANOTHER_DATABASE_APP_NAME,
     )
     await ops_test.model.wait_for_idle(apps=APP_NAMES, status="active")
 

--- a/tests/unit/test_database_provides.py
+++ b/tests/unit/test_database_provides.py
@@ -3,7 +3,12 @@
 import unittest
 from unittest.mock import Mock, patch
 
-from charms.data_platform_libs.v0.database_provides import DatabaseProvides, Diff
+from charms.data_platform_libs.v0.database_provides import (
+    DatabaseProvides,
+    DatabaseRequestedEvent,
+    Diff,
+)
+from charms.harness_extensions.v0.capture_events import capture
 from ops.charm import CharmBase
 from ops.testing import Harness
 
@@ -165,3 +170,10 @@ class TestDatabaseProvides(unittest.TestCase):
         # (the diff/data key should not be present).
         data = self.harness.charm.database.fetch_relation_data()
         assert data == {self.rel_id: {"database": DATABASE}}
+
+    def test_database_requested_event(self):
+        # Test custom event creation
+
+        with capture(self.harness.charm, DatabaseRequestedEvent) as captured:
+            self.harness.update_relation_data(self.rel_id, "application", {"database": DATABASE})
+        assert captured.event.app.name == "application"

--- a/tests/unit/test_database_provides.py
+++ b/tests/unit/test_database_provides.py
@@ -174,6 +174,15 @@ class TestDatabaseProvides(unittest.TestCase):
     def test_database_requested_event(self):
         # Test custom event creation
 
+        # Test the event being emitted by the application.
         with capture(self.harness.charm, DatabaseRequestedEvent) as captured:
             self.harness.update_relation_data(self.rel_id, "application", {"database": DATABASE})
         assert captured.event.app.name == "application"
+
+        # Reset the diff data to trigger the event again later.
+        self.harness.update_relation_data(self.rel_id, "database", {"data": "{}"})
+
+        # Test the event being emitted by the unit.
+        with capture(self.harness.charm, DatabaseRequestedEvent) as captured:
+            self.harness.update_relation_data(self.rel_id, "application/0", {"database": DATABASE})
+        assert captured.event.unit.name == "application/0"

--- a/tests/unit/test_database_requires.py
+++ b/tests/unit/test_database_requires.py
@@ -313,7 +313,11 @@ class TestDatabaseRequires(unittest.TestCase):
 
         # Call the emit function and assert the desired event is triggered.
         relation = self.harness.charm.model.get_relation(RELATION_NAME, self.rel_id)
-        self.harness.charm.database._emit_aliased_event(relation, "database_created")
+        mock_event = Mock()
+        mock_event.app = self.harness.charm.model.get_app("application")
+        mock_event.unit = self.harness.charm.model.get_unit("application/0")
+        mock_event.relation = relation
+        self.harness.charm.database._emit_aliased_event(mock_event, "database_created")
         _on_cluster1_database_created.assert_called_once()
 
     def test_get_relation_alias(self):


### PR DESCRIPTION
# Issue
The emitter of DatabaseRequestedEvent don't set values to the event.unit nor event.app properties inherited from RelationEvent, so they are both defaulted to None https://github.com/canonical/data-platform-libs/issues/14.

The same applies to the requires side of the relation.

# Solution
* Use the app and the unit from the original event in the function that emits the custom events.

# Context
* Skip `lib/charms/harness_extensions/v0/capture_events.py` when reviewing this PR (it is an imported library). For more details, check [this](https://discourse.charmhub.io/t/harness-recipe-capture-events/6581).

# Testing
* Unit tests were updated and some new tests were implemented.

# Release Notes
* Add app and unit information to custom events.