### PR TITLE
Rename relation interface names

### DIFF
--- a/tests/integration/application-charm/metadata.yaml
+++ b/tests/integration/application-charm/metadata.yaml
@@ -9,11 +9,11 @@ summary: |
 
 requires:
   first-database:
-    interface: database-client
+    interface: database_client
   second-database:
-    interface: database-client
+    interface: database_client
   multiple-database-clusters:
-    interface: database-client
+    interface: database_client
   aliased-multiple-database-clusters:
-    interface: database-client
+    interface: database_client
     limit: 2

--- a/tests/integration/database-charm/metadata.yaml
+++ b/tests/integration/database-charm/metadata.yaml
@@ -22,7 +22,7 @@ resources:
 
 provides:
   database:
-    interface: database-client
+    interface: database_client
 
 storage:
   database:

--- a/tests/unit/test_database_provides.py
+++ b/tests/unit/test_database_provides.py
@@ -14,7 +14,7 @@ from ops.testing import Harness
 
 DATABASE = "data_platform"
 EXTRA_USER_ROLES = "CREATEDB,CREATEROLE"
-RELATION_INTERFACE = "database-client"
+RELATION_INTERFACE = "database_client"
 RELATION_NAME = "database"
 METADATA = f"""
 name: database

--- a/tests/unit/test_database_requires.py
+++ b/tests/unit/test_database_requires.py
@@ -19,7 +19,7 @@ from ops.testing import Harness
 CLUSTER_ALIASES = ["cluster1", "cluster2"]
 DATABASE = "data_platform"
 EXTRA_USER_ROLES = "CREATEDB,CREATEROLE"
-RELATION_INTERFACE = "database-client"
+RELATION_INTERFACE = "database_client"
 RELATION_NAME = "database"
 METADATA = f"""
 name: application


### PR DESCRIPTION
# Issue
Relation interface name must not include hyphens.

# Solution
Change `-` to `_` in the relation interface names.

# Context
It is also being changed in this repository to not create confusion for people about how to name interfaces of relations when they start using the relation libraries.

# Release Notes
* Rename relation interface names.