### PR TITLE
Include DatabaseCreatedEvent in sample code

### DIFF
--- a/lib/charms/data_platform_libs/v0/database_requires.py
+++ b/lib/charms/data_platform_libs/v0/database_requires.py
@@ -23,7 +23,10 @@ application charm code:
 
 ```python
 
-from charms.data_platform_libs.v0.database_requires import DatabaseRequires
+from charms.data_platform_libs.v0.database_requires import (
+    DatabaseCreatedEvent,
+    DatabaseRequires,
+)
 
 class ApplicationCharm(CharmBase):
     # Application charm that connects to database charms.
@@ -84,7 +87,10 @@ The implementation would be something like the following code:
 
 ```python
 
-from charms.data_platform_libs.v0.database_requires import DatabaseRequires
+from charms.data_platform_libs.v0.database_requires import (
+    DatabaseCreatedEvent,
+    DatabaseRequires,
+)
 
 class ApplicationCharm(CharmBase):
     # Application charm that connects to database charms.


### PR DESCRIPTION
Trivial change updating the docstring for the database requires side of the relation to mention that you also need to import the `DatabaseCreatedEvent` as it's referenced in the sample code below.