### PR TITLE
Add missing workflow_call trigger to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,7 @@
 name: PR Tests
 on:
   pull_request:
+  workflow_call:
 
 jobs:
   lint:


### PR DESCRIPTION
Add the missing `workflow_call` trigger on `ci.yaml`. Without that, it's not possible to reuse the workflow on other workflows like `release.yaml`.

This need was reported on https://github.com/canonical/data-platform-libs/actions/runs/3249715434.

I missed that on https://github.com/canonical/data-platform-libs/pull/24 (Jira issue: [DPE-787](https://warthogs.atlassian.net/browse/DPE-787))