### PR TITLE
Bump database_provides/requires LIBPATCH version to fix publishing

### DIFF
--- a/lib/charms/data_platform_libs/v0/database_provides.py
+++ b/lib/charms/data_platform_libs/v0/database_provides.py
@@ -80,7 +80,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 logger = logging.getLogger(__name__)
 

--- a/lib/charms/data_platform_libs/v0/database_requires.py
+++ b/lib/charms/data_platform_libs/v0/database_requires.py
@@ -160,7 +160,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version.
-LIBPATCH = 4
+LIBPATCH = 5
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Currently publishing is not possible:

> cd data-platform-libs.git && charmcraft publish-lib
> ...
> Library charms.data_platform_libs.v0.database_provides version 0.2 is the same than in Charmhub but content is different
> Library charms.data_platform_libs.v0.database_requires version 0.4 is the same than in Charmhub but content is different
> ...

Suspected commits f093eff04c5ead8ef80d2df35e609ac0eb062bed and 48e900386b3df0d40fdfb59e3d668b0f66d79457 (merged without bumping LIBPATCH).