### PR TITLE
Bump charming-actions to 2.2.2 (to fix release-libraries@2.2.0)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check libs
-        uses: canonical/charming-actions/check-libraries@2.2.0
+        uses: canonical/charming-actions/check-libraries@2.2.2
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}" # FIXME: current token will expire in 2025-04-16
           github-token: "${{ secrets.GITHUB_TOKEN }}"
@@ -35,15 +35,15 @@ jobs:
         with:
           fetch-depth: 0
       - name: Release any bumped charm libs
-        uses: canonical/charming-actions/release-libraries@2.2.0
+        uses: canonical/charming-actions/release-libraries@2.2.2
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@2.2.0
+        uses: canonical/charming-actions/channel@2.2.2
         id: channel
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.2.0
+        uses: canonical/charming-actions/upload-charm@2.2.2
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}" # FIXME: current token will expire in 2025-04-16
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
At the moment, the current release-libraries@2.2.0 is failing with really strange error:
https://github.com/canonical/data-platform-libs/actions/runs/4067139974/jobs/7004849787
> Error: Not Found
> Error: HttpError: Not Found
>     at /home/runner/work/_actions/canonical/charming-actions/2.2.0/dist/release-libraries/index.js:8603:21
>     at processTicksAndRejections (internal/process/task_queues.js:97:5)

The version 2.2.1 has related fix:
https://github.com/canonical/charming-actions/releases/tag/2.2.1
> This patch unlocks the ability to run release-libraries on push events to main,
> which is a way less error-prone approach than publishing directly on PR create.

Let's update charming-actions to the latest 2.2.2 which looks stable for other repos.