### PR TITLE
Bump juju to 2.9.38, libjuju to 2.9.38.1 and remove flake8 pinning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,8 +39,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          # This is needed until https://bugs.launchpad.net/juju/+bug/1992833 is fixed.
-          bootstrap-options: "--agent-version 2.9.34"
+          bootstrap-options: "--agent-version 2.9.38"
       - name: Run integration tests
         # set a predictable model name so it can be consumed by charm-logdump-action
         run: tox -e integration -- --model testing

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8==4.0.1
+    flake8
     flake8-docstrings
     flake8-copyright
     flake8-builtins
@@ -70,7 +70,7 @@ description = Run integration tests
 deps =
     psycopg2-binary
     pytest
-    juju==2.9.11
+    juju==2.9.38.1
     pytest-operator
     -r{toxinidir}/requirements.txt
 commands =


### PR DESCRIPTION
Update components to the latest versions in Juju 2.9 LTS.
The old pinning should no longer be necessary.