### PR TITLE
Fix typo Kakfa -> Kafka

### DIFF
--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -1159,7 +1159,7 @@ class KafkaRequires(DataRequires):
             # “endpoints_changed“ event if “topic_created“ is triggered.
             return
 
-        # Emit an endpoints (bootstap-server) changed event if the Kakfa endpoints
+        # Emit an endpoints (bootstap-server) changed event if the Kafka endpoints
         # added or changed this info in the relation databag.
         if "endpoints" in diff.added or "endpoints" in diff.changed:
             # Emit the default event (the one without an alias).

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -16,7 +16,7 @@
 
 This library contains the Requires and Provides classes for handling the relation
 between an application and multiple managed application supported by the data-team:
-MySQL, Postgresql, MongoDB, Redis,  and Kakfa.
+MySQL, Postgresql, MongoDB, Redis, and Kafka.
 
 ### Database (MySQL, Postgresql, MongoDB, and Redis)
 
@@ -303,7 +303,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 9
 
 PYDEPS = ["ops>=2.0.0"]
 

--- a/tests/integration/kafka-charm/metadata.yaml
+++ b/tests/integration/kafka-charm/metadata.yaml
@@ -4,7 +4,7 @@ name: kafka
 description: |
   Toy charm used to emulate Kafka in integration tests.
 summary: |
-  Charm used to mimic the Kakfa charm for test purpose only.
+  Charm used to mimic the Kafka charm for test purpose only.
 
 
 peers:

--- a/tests/integration/kafka-charm/src/charm.py
+++ b/tests/integration/kafka-charm/src/charm.py
@@ -77,7 +77,7 @@ class KafkaCharm(CharmBase):
 
     def _on_start(self, _) -> None:
         """Only sets an active status."""
-        self.unit.status = ActiveStatus("Kakfa Ready!")
+        self.unit.status = ActiveStatus("Kafka Ready!")
 
     def _on_topic_requested(self, event: TopicRequestedEvent):
         """Handle the on_topic_requested event."""

--- a/tests/unit/test_data_interfaces.py
+++ b/tests/unit/test_data_interfaces.py
@@ -895,7 +895,7 @@ class TestDatabaseRequires(DataRequirerBaseTests, unittest.TestCase):
                 assert captured.unit.name == f"{self.provider}/0"
 
 
-class TestKakfaRequires(DataRequirerBaseTests, unittest.TestCase):
+class TestKafkaRequires(DataRequirerBaseTests, unittest.TestCase):
     metadata = METADATA
     relation_name = KAFKA_RELATION_NAME
     charm = ApplicationCharmKafka


### PR DESCRIPTION
It is a typo spotted by new codespell and affect other repos, like https://github.com/canonical/kafka-bundle/actions/runs/4373173395/jobs/7651007585