### PR TITLE
[MISC] Bug fix writing in the local unit instead of local app

### DIFF
--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -534,7 +534,7 @@ class DataRequires(Object, ABC):
             a Diff instance containing the added, deleted and changed
                 keys from the event relation databag.
         """
-        return diff(event, self.local_unit)
+        return diff(event, self.local_app)
 
     @property
     def relations(self) -> List[Relation]:


### PR DESCRIPTION
I have noticed that the Requirer side write the "data" field (used for computing differences) in the local_unit instead of the local_app