### PR TITLE
Add is_postgresql_plugin_enabled method

### DIFF
--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -927,8 +927,13 @@ class DatabaseRequires(DataRequires):
                 return relation.data[self.local_unit].get("alias")
         return None
 
-    def is_postgresql_plugin_enabled(self, plugin: str) -> bool:
+    def is_postgresql_plugin_enabled(self, plugin: str, relation_index: int = 0) -> bool:
         """Returns whether a plugin is enabled in the database.
+
+        Args:
+            plugin: name of the plugin to check.
+            relation_index: optional relation index to check the database
+                (default: 0 - first relation).
 
         PostgreSQL only.
         """
@@ -940,7 +945,7 @@ class DatabaseRequires(DataRequires):
         if len(self.relations) == 0:
             return False
 
-        relation_data = self.fetch_relation_data()[self.relations[0].id]
+        relation_data = self.fetch_relation_data()[self.relations[relation_index].id]
         host = relation_data.get("endpoints")
 
         # Return False if there is no endpoint available.

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -941,7 +941,6 @@ class DatabaseRequires(DataRequires):
             return False
 
         relation_data = self.fetch_relation_data()[self.relations[0].id]
-        logger.error(f"relation_data: {relation_data}")
         host = relation_data.get("endpoints")
 
         # Return False if there is no endpoint available.

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -144,6 +144,19 @@ class ApplicationCharm(CharmBase):
 
 ```
 
+When it's needed to check whether a plugin (extension) is enabled on the PostgreSQL
+charm, you can use the is_postgresql_plugin_enabled method. To use that, you need to
+add the following dependency to your charmcraft.yaml file:
+
+```yaml
+
+parts:
+  charm:
+    charm-binary-python-packages:
+      - psycopg[binary]
+
+```
+
 ### Provider Charm
 
 Following an example of using the DatabaseRequestedEvent, in the context of the

--- a/tests/integration/application-charm/actions.yaml
+++ b/tests/integration/application-charm/actions.yaml
@@ -1,2 +1,11 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+get-plugin-status:
+  description: Get plugin status (enabled/disabled).
+  params:
+    plugin:
+      type: string
+      description: The plugin to check the status.
+
 reset-unit-status:
   description: Set empty status message (ActiveStatus)

--- a/tests/integration/application-charm/charmcraft.yaml
+++ b/tests/integration/application-charm/charmcraft.yaml
@@ -9,3 +9,7 @@ bases:
     run-on:
       - name: "ubuntu"
         channel: "22.04"
+parts:
+  charm:
+    charm-binary-python-packages:
+      - psycopg[binary]

--- a/tox.ini
+++ b/tox.ini
@@ -57,6 +57,7 @@ commands =
 description = Run unit tests
 deps =
     parameterized
+    psycopg[binary]
     pytest
     coverage[toml]
     -r {tox_root}/requirements.txt


### PR DESCRIPTION
## Issue
Jira ticket: [DPE-1373](https://warthogs.atlassian.net/browse/DPE-1373)

As an juju admin, I should be able to run:

* `juju relate postgresql-k8s:postgresql_client TODO_charmname:postgresql_client`

* New relation requests do not contain extensions information but “data_interfaces” library which implements new relation should have “is_postgresql_plugin_enabled” function. This function returns True or False depending if the extension is installed and configured.

* (with new relation) the application charm expects to set blocked status to forcing users to enable extension manually through config options (https://github.com/canonical/postgresql-operator/pull/139).

## Solution
Created the new method and add a local import to psycopg to avoid requiring that application charms not using the new method need to install psycopg as a dependency.

Added unit and integration tests.

[DPE-1373]: https://warthogs.atlassian.net/browse/DPE-1373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ