### PR TITLE
chore: core structure of base DataUpgrade lib and handlers for pre upgrade-charm

### DIFF
--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -308,7 +308,7 @@ class DependencyModel(BaseModel):
     def upgrade_supported_validator(
         cls, values
     ) -> dict[str, dict[str, Dependency] | str | Dependency]:
-        """Validates specified `version` is not behind specified `upgrade_supported` requirement."""
+        """Validates specified `version` meets `upgrade_supported` requirement."""
         if not verify_requirements(
             version=values.get("version"), requirement=values.get("upgrade_supported")
         ):

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -231,7 +231,7 @@ class DependencyModel(BaseModel):
         values = str(value.values()) if isinstance(value, dict) else value
 
         if (count := sum([values.count(char) for char in chars])) > 1:
-            raise ValueError(f"Value uses greater than 1 special character (^ ~ > *).")
+            raise ValueError(f"Value uses greater than 1 special character (^ ~ > *). Found {count}.")
 
         return value
 

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -1,5 +1,4 @@
 from abc import abstractmethod
-from typing import Any
 from ops.charm import (
     ActionEvent,
     CharmBase,
@@ -10,9 +9,7 @@ from ops.charm import (
 from ops.framework import EventBase, Object
 from ops.model import Relation
 import logging
-import pydantic
-from pydantic import BaseModel, ValidationError, root_validator, validator
-import re
+from pydantic import BaseModel, root_validator, validator
 
 
 # The unique Charmhub library identifier, never change it

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -81,12 +81,10 @@ def verify_caret_requirements(version: str, requirement: str) -> bool:
             break
 
     for i in range(3):
-        if (i == max_version_index) and (sem_version[i] != sem_requirement[i]):
-            logger.info("larger than max at index")
+        if (i < max_version_index) and (sem_version[i] > sem_requirement[i]):
             return False
 
-        if (i < max_version_index) and (sem_version[i] > sem_requirement[i]):
-            logger.info("larger than max before index")
+        if (i == max_version_index) and (sem_version[i] != sem_requirement[i]):
             return False
 
         if (i > max_version_index) and (sem_version[i] > sem_requirement[i]):
@@ -107,12 +105,23 @@ def verify_tilde_requirements(version: str, requirement: str) -> bool:
     """
     if not requirement.startswith("~"):
         return True
+    else:
+        requirement = requirement[1:]
 
-    versions = version.split(".")
-    requirements = requirement.split(".")
+    sem_version = build_complete_sem_ver(version)
+    sem_requirement = build_complete_sem_ver(requirement)
 
-    if versions[0] >= requirements[0]:
-        return False
+    max_version_index = min(1, requirement.count("."))
+
+    for i in range(3):
+        if (i < max_version_index) and (sem_version[i] > sem_requirement[i]):
+            return False
+
+        if (i == max_version_index) and (sem_version[i] != sem_requirement[i]):
+            return False
+
+        if (i > max_version_index) and (sem_version[i] < sem_requirement[i]):
+            return False
 
     return True
 

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -1,4 +1,23 @@
+# Copyright 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Handler for `upgrade` relation events for in-place upgrades on VMs."""
+
+import logging
 from abc import abstractmethod
+from typing import Any
+
 from ops.charm import (
     ActionEvent,
     CharmBase,
@@ -8,9 +27,7 @@ from ops.charm import (
 )
 from ops.framework import EventBase, Object
 from ops.model import Relation
-import logging
 from pydantic import BaseModel, root_validator, validator
-
 
 # The unique Charmhub library identifier, never change it
 LIBID = "156258aefb79435a93d933409a8c8684"

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -1,5 +1,13 @@
-from ops.charm import ActionEvent, CharmBase, RelationChangedEvent, RelationEvent, UpgradeCharmEvent
+from abc import abstractmethod
+from ops.charm import (
+    ActionEvent,
+    CharmBase,
+    RelationChangedEvent,
+    UpgradeCharmEvent,
+)
 from ops.framework import EventBase, Object
+from overrides import override
+import logging
 
 
 # The unique Charmhub library identifier, never change it
@@ -12,8 +20,52 @@ LIBAPI = 0
 # to 0 if you are raising the major API version
 LIBPATCH = 1
 
+logger = logging.getLogger(__name__)
+
+class UpgradeError(Exception):
+    """Base class for upgrade related exceptions in the module.
+
+    Args:
+        `message`: string message to be logged out
+        `cause`: short human-readable description of the cause of the error (optional)
+        `resolution`: short human-readable instructions for manual solutions to the error (optional)
+    """
+    def __init__(self, message: str, cause: str | None, resolution: str | None):
+        super().__init__(message)
+        self.cause = cause
+        self.resolution = resolution
+
+    def __repr__(self):
+        """String representation of the UpgradeError class."""
+        return f"{type(self).__module__}.{type(self).__name__} {self.args}"
+
+
+class ClusterNotReadyError(UpgradeError):
+    """Exception flagging that the cluster is not ready to start upgrading.
+
+    Args:
+        `message`: string message to be logged out
+        `cause`: short human-readable description of the cause of the error
+        `resolution`: short human-readable instructions for manual solutions to the error (optional)
+    """
+    def __init__(self, message: str, cause: str, resolution: str | None = None):
+        super().__init__(message, cause=cause, resolution=resolution)
+
+class UpgradeFailedError(UpgradeError):
+    """Exception flagging that something in the upgrade process failed, and should be aborted.
+
+    Args:
+        `message`: string message to be logged out
+        `cause`: short human-readable description of the cause of the error
+        `resolution`: short human-readable instructions for manual solutions to the error
+    """
+    def __init__(self, message: str, cause: str, resolution: str):
+        super().__init__(message, cause=cause, resolution=resolution)
+
+
 class UpgradeGrantedEvent(EventBase):
     """Used to tell units that they can process an upgrade."""
+
 
 class DataUpgrade(Object):
     """Manages `upgrade` relations."""
@@ -23,13 +75,44 @@ class DataUpgrade(Object):
         self.charm = charm
         self.relation_name = relation_name
 
-        self.framework.observe(self.charm.on[relation_name].relation_changed, self._on_upgrade_changed)
+        self.framework.observe(
+            self.charm.on[relation_name].relation_changed, self._on_upgrade_changed
+        )
 
     def _on_upgrade_changed(self, event: RelationChangedEvent):
         raise NotImplementedError
 
     def _on_pre_upgrade_check_action(self, event: ActionEvent):
-        raise NotImplementedError
+        if not self.charm.unit.is_leader():
+            event.fail(message="Action must be ran on the Juju leader for the application.")
+            return
+
+        try:
+            self.pre_upgrade_check()
+        except ClusterNotReadyError as e:
+            logger.error(str(e))
+            event.fail(message="Action must be ran on the Juju leader for the application.")
 
     def _on_upgrade_charm(self, event: UpgradeCharmEvent):
         raise NotImplementedError
+
+    @abstractmethod
+    def pre_upgrade_check(self) -> None:
+        """Runs necessary checks validating the cluster is in a healthy state to upgrade.
+
+        Raises:
+            ClusterNotReadyError: if cluster is not ready to upgrade
+        """
+        pass
+
+    @abstractmethod
+    def build_upgrade_stack(self) -> list[str]:
+        """Builds ordered list of all application unit.ids to upgrade in.
+
+        Returns:
+            List of integeter unit.ids, ordered by upgrade order
+                e.g [5, 2, 4, 1, 3]
+        """
+        pass
+
+

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -79,7 +79,7 @@ def verify_tilde_requirements(version: str, requirement: str) -> bool:
 
     Args:
         `version`: the version currently in use
-        `requiremeent`: the requirement version
+        `requirement`: the requirement version
 
     Returns:
         True if `version` meets defined `requirement`. Otherwise False
@@ -106,12 +106,13 @@ def verify_tilde_requirements(version: str, requirement: str) -> bool:
 
     return True
 
+
 def verify_wildcard_requirements(version: str, requirement: str) -> bool:
     """Verifies version requirements using wildcards.
 
     Args:
         `version`: the version currently in use
-        `requiremeent`: the requirement version
+        `requirement`: the requirement version
 
     Returns:
         True if `version` meets defined `requirement`. Otherwise False
@@ -132,6 +133,43 @@ def verify_wildcard_requirements(version: str, requirement: str) -> bool:
             return False
 
     return True
+
+
+def verify_inequality_requirements(version: str, requirement: str) -> bool:
+    """Verifies version requirements using inequalities.
+
+    Args:
+        `version`: the version currently in use
+        `requirement`: the requirement version
+
+    Returns:
+        True if `version` meets defined `requirement`. Otherwise False
+    """
+    if not any([char for char in [">", ">="] if requirement.startswith(char)]):
+        return True
+    else:
+        raw_requirement = requirement.replace(">", "").replace("=", "")
+
+    sem_version = build_complete_sem_ver(version)
+    sem_requirement = build_complete_sem_ver(raw_requirement)
+
+    max_version_index = raw_requirement.count(".") or 0
+
+    for i in range(3):
+        if (
+            (i == max_version_index)
+            and ("=" in requirement)
+            and (sem_version[i] == sem_requirement[i])
+        ):
+            return True
+
+        if sem_version[i] < sem_requirement[i]:
+            return False
+
+        if sem_version[i] > sem_requirement[i]:
+            return True
+
+    return False
 
 
 class DependencyModel(BaseModel):

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -322,7 +322,7 @@ class ClusterNotReadyError(UpgradeError):
     Args:
         `message`: string message to be logged out
         `cause`: short human-readable description of the cause of the error
-        `resolution`: short human-readable instructions for manual solutions to the error (optional)
+        `resolution`: short human-readable instructions for manual error resolution (optional)
     """
 
     def __init__(self, message: str, cause: str, resolution: str | None = None):

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -1,0 +1,35 @@
+from ops.charm import ActionEvent, CharmBase, RelationChangedEvent, RelationEvent, UpgradeCharmEvent
+from ops.framework import EventBase, Object
+
+
+# The unique Charmhub library identifier, never change it
+LIBID = "156258aefb79435a93d933409a8c8684"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+class UpgradeGrantedEvent(EventBase):
+    """Used to tell units that they can process an upgrade."""
+
+class DataUpgrade(Object):
+    """Manages `upgrade` relations."""
+
+    def __init__(self, charm: CharmBase, relation_name: str = "upgrade"):
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+
+        self.framework.observe(self.charm.on[relation_name].relation_changed, self._on_upgrade_changed)
+
+    def _on_upgrade_changed(self, event: RelationChangedEvent):
+        raise NotImplementedError
+
+    def _on_pre_upgrade_check_action(self, event: ActionEvent):
+        raise NotImplementedError
+
+    def _on_upgrade_charm(self, event: UpgradeCharmEvent):
+        raise NotImplementedError

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -58,8 +58,8 @@ def verify_caret_requirements(version: str, requirement: str) -> bool:
     """Verifies version requirements using carats.
 
     Args:
-        `version`: the version currently in use
-        `requiremeent`: the requirement version
+        version: the version currently in use
+        requirement: the requirement version
 
     Returns:
         True if `version` meets defined `requirement`. Otherwise False
@@ -99,8 +99,8 @@ def verify_tilde_requirements(version: str, requirement: str) -> bool:
     """Verifies version requirements using tildes.
 
     Args:
-        `version`: the version currently in use
-        `requirement`: the requirement version
+        version: the version currently in use
+        requirement: the requirement version
 
     Returns:
         True if `version` meets defined `requirement`. Otherwise False
@@ -136,8 +136,8 @@ def verify_wildcard_requirements(version: str, requirement: str) -> bool:
     """Verifies version requirements using wildcards.
 
     Args:
-        `version`: the version currently in use
-        `requirement`: the requirement version
+        version: the version currently in use
+        requirement: the requirement version
 
     Returns:
         True if `version` meets defined `requirement`. Otherwise False
@@ -167,8 +167,8 @@ def verify_inequality_requirements(version: str, requirement: str) -> bool:
     """Verifies version requirements using inequalities.
 
     Args:
-        `version`: the version currently in use
-        `requirement`: the requirement version
+        version: the version currently in use
+        requirement: the requirement version
 
     Returns:
         True if `version` meets defined `requirement`. Otherwise False
@@ -210,8 +210,8 @@ def verify_requirements(version: str, requirement: str) -> bool:
     Supports caret (^), tilde (~), wildcard (*) and greater-than inequalities (>, >=)
 
     Args:
-        `version`: the version currently in use
-        `requirement`: the requirement version
+        version: the version currently in use
+        requirement: the requirement version
 
     Returns:
         True if `version` meets defined `requirement`. Otherwise False

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -22,22 +22,23 @@ LIBPATCH = 1
 
 logger = logging.getLogger(__name__)
 
-class UpgradeError(Exception):
-    """Base class for upgrade related exceptions in the module.
 
-    Args:
-        `message`: string message to be logged out
-        `cause`: short human-readable description of the cause of the error (optional)
-        `resolution`: short human-readable instructions for manual solutions to the error (optional)
-    """
+class UpgradeError(Exception):
+    """Base class for upgrade related exceptions in the module."""
+
     def __init__(self, message: str, cause: str | None, resolution: str | None):
         super().__init__(message)
-        self.cause = cause
-        self.resolution = resolution
+        self.message = message
+        self.cause = cause or ""
+        self.resolution = resolution or ""
 
     def __repr__(self):
+        """Representation of the UpgradeError class."""
+        return f"{type(self).__module__}.{type(self).__name__} - {str(vars(self))}"
+
+    def __str__(self):
         """String representation of the UpgradeError class."""
-        return f"{type(self).__module__}.{type(self).__name__} {self.args}"
+        return repr(self)
 
 
 class ClusterNotReadyError(UpgradeError):
@@ -48,8 +49,10 @@ class ClusterNotReadyError(UpgradeError):
         `cause`: short human-readable description of the cause of the error
         `resolution`: short human-readable instructions for manual solutions to the error (optional)
     """
+
     def __init__(self, message: str, cause: str, resolution: str | None = None):
         super().__init__(message, cause=cause, resolution=resolution)
+
 
 class UpgradeFailedError(UpgradeError):
     """Exception flagging that something in the upgrade process failed, and should be aborted.
@@ -59,6 +62,7 @@ class UpgradeFailedError(UpgradeError):
         `cause`: short human-readable description of the cause of the error
         `resolution`: short human-readable instructions for manual solutions to the error
     """
+
     def __init__(self, message: str, cause: str, resolution: str):
         super().__init__(message, cause=cause, resolution=resolution)
 
@@ -90,7 +94,7 @@ class DataUpgrade(Object):
         try:
             self.pre_upgrade_check()
         except ClusterNotReadyError as e:
-            logger.error(str(e))
+            logger.error(e)
             event.fail(message="Action must be ran on the Juju leader for the application.")
 
     def _on_upgrade_charm(self, event: UpgradeCharmEvent):
@@ -114,5 +118,3 @@ class DataUpgrade(Object):
                 e.g [5, 2, 4, 1, 3]
         """
         pass
-
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,40 @@ docstring-convention = "google"
 copyright-check = "True"
 copyright-author = "Canonical Ltd."
 copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
+
+[tool.ruff]
+line-length = 99
+select = ["E", "W", "F", "C", "N", "D", "I001"]
+extend-ignore = [
+    "D203",
+    "D204",
+    "D213",
+    "D215",
+    "D400",
+    "D401",
+    "D404",
+    "D406",
+    "D407",
+    "D408",
+    "D409",
+    "D413",
+]
+ignore = ["E501", "D107"]
+extend-exclude = ["__pycache__", "*.egg_info"]
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104", "E999"], "src/literals.py" = ["D101"]}
+target-version="py310"
+src = ["src", "tests"]
+
+[tool.ruff.mccabe]
+max-complexity = 10
+
+[tool.pyright]
+include = ["src"]
+extraPaths = ["./lib"]
+pythonVersion = "3.10"
+pythonPlatform = "All"
+typeCheckingMode = "basic"
+reportIncompatibleMethodOverride = false
+reportImportCycles = false
+reportMissingModuleSource = true
+stubPath = ""

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -1,18 +1,9 @@
-import logging
 import pytest
 from charms.data_platform_libs.v0.upgrade import (
-    reduce_versions,
     build_complete_sem_ver,
     verify_caret_requirements,
     verify_tilde_requirements,
 )
-
-
-@pytest.mark.parametrize(
-    "version,output", [("0.0.24.0.4", "24.0.4"), ("3.5.3", "3.5.3"), ("0.3", "3")]
-)
-def test_reduce_versions(version, output):
-    assert reduce_versions(version) == output
 
 
 @pytest.mark.parametrize(
@@ -22,6 +13,11 @@ def test_reduce_versions(version, output):
         ("3.5.3", [3, 5, 3]),
         ("0.3", [0, 3, 0]),
         ("1.2", [1, 2, 0]),
+        ("3.5.*", [3, 5, 0]),
+        ("0.*", [0, 0, 0]),
+        ("1.*", [1, 0, 0]),
+        ("1.2.*", [1, 2, 0]),
+        ("*", [0, 0, 0]),
         (1, [1, 0, 0]),
     ],
 )

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -2,6 +2,7 @@ import pytest
 from charms.data_platform_libs.v0.upgrade import (
     build_complete_sem_ver,
     verify_caret_requirements,
+    verify_inequality_requirements,
     verify_tilde_requirements,
     verify_wildcard_requirements,
 )
@@ -95,6 +96,7 @@ def test_verify_caret_requirements(requirement, version, output):
 def test_verify_tilde_requirements(requirement, version, output):
     assert verify_tilde_requirements(version=version, requirement=requirement) == output
 
+
 @pytest.mark.parametrize(
     "requirement,version,output",
     [
@@ -122,3 +124,51 @@ def test_verify_tilde_requirements(requirement, version, output):
 )
 def test_verify_wildcard_requirements(requirement, version, output):
     assert verify_wildcard_requirements(version=version, requirement=requirement) == output
+
+
+@pytest.mark.parametrize(
+    "requirement,version,output",
+    [
+        ("~1", "1", True),
+        ("^0", "1", True),
+        ("0", "0.1", True),
+        (">1", "1.8", True),
+        (">1", "8.8.0", True),
+        (">0", "8.8.0", True),
+        (">0", "0.0", False),
+        (">0", "0.0.0", False),
+        (">0", "0.0.1", True),
+        (">1.0", "1.0.0", False),
+        (">1.0", "1.0", False),
+        (">1.0", "1.5.6", True),
+        (">1.0", "2.0", True),
+        (">1.0", "0.0.4", False),
+        (">1.6", "1.3", False),
+        (">1.6", "1.3.8", False),
+        (">1.6", "1.35.8", True),
+        (">1.6.3", "1.7.8", True),
+        (">1.22.3", "1.7.8", False),
+        (">0.22.3", "1.7.8", True),
+        (">=1.0", "1.0.0", True),
+        (">=1.0", "1.0", True),
+        (">=0.2", "0.2", True),
+        (">=0.2.7", "0.2.7", True),
+        (">=1.0", "1.5.6", True),
+        (">=1", "1", True),
+        (">=1", "1.0", True),
+        (">=1", "1.0.0", True),
+        (">=1", "1.0.6", True),
+        (">=1", "0.0", False),
+        (">=1", "0.0.1", False),
+        (">=1.0", "2.0", True),
+        (">=1.0", "0.0.4", False),
+        (">=1.6", "1.3", False),
+        (">=1.6", "1.3.8", False),
+        (">=1.6", "1.35.8", True),
+        (">=1.6.3", "1.7.8", True),
+        (">=1.22.3", "1.7.8", False),
+        (">=0.22.3", "1.7.8", True),
+    ],
+)
+def test_verify_inequality_requirements(requirement, version, output):
+    assert verify_inequality_requirements(version=version, requirement=requirement) == output

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -265,3 +265,18 @@ def test_dependency_model_succeeds():
         gandalf_the_white: DependencyModel
 
     GandalfModel(**deps)
+
+def test_dependency_model_succeeds_nested():
+    deps = {
+        "gandalf_the_white": {
+            "dependencies": {"gandalf_the_grey": "~1.0", "durin": "^1.2.5"},
+            "name": "gandalf",
+            "upgrade_supported": ">1.2",
+            "version": "7",
+        },
+    }
+
+    class GandalfModel(BaseModel):
+        gandalf_the_white: DependencyModel
+
+    GandalfModel(**deps)

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -28,9 +28,12 @@ def test_reduce_versions(version, output):
 def test_build_complete_sem_ver(version, output):
     assert build_complete_sem_ver(version) == output
 
+
 @pytest.mark.parametrize(
     "requirement,version,output",
     [
+        ("~1.2.3", "1.2.2", True),
+        ("1.2.3", "1.2.2", True),
         ("^1.2.3", "1.2.2", False),
         ("^1.2.3", "1.3", True),
         ("^1.2.3", "2.2.5", False),
@@ -60,3 +63,37 @@ def test_build_complete_sem_ver(version, output):
 )
 def test_verify_caret_requirements(requirement, version, output):
     assert verify_caret_requirements(version=version, requirement=requirement) == output
+
+
+@pytest.mark.parametrize(
+    "requirement,version,output",
+    [
+        ("^1.2.3", "1.2.2", True),
+        ("1.2.3", "1.2.2", True),
+        ("~1.2.3", "1.2.2", False),
+        ("~1.2.3", "1.3.2", False),
+        ("~1.2.3", "1.3.5", False),
+        ("~1.2.3", "1.2.5", True),
+        ("~1.2.3", "1.2", False),
+        ("~1.2", "1.2", True),
+        ("~1.2", "1.6", False),
+        ("~1.2", "1.2.4", True),
+        ("~1.2", "1.1", False),
+        ("~1.2", "1.0.5", False),
+        ("~0.2", "0.2", True),
+        ("~0.2", "0.2.3", True),
+        ("~0.2", "0.3", False),
+        ("~1", "0.3", False),
+        ("~1", "1.3", True),
+        ("~1", "0.0.9", False),
+        ("~1", "0.9.9", False),
+        ("~1", "1.9.9", True),
+        ("~1", "1.7", True),
+        ("~1", "1", True),
+        ("~0", "1", False),
+        ("~0", "0.1", True),
+        ("~0", "0.5.9", True),
+    ],
+)
+def test_verify_tilde_requirements(requirement, version, output):
+    assert verify_tilde_requirements(version=version, requirement=requirement) == output

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -3,6 +3,7 @@ from charms.data_platform_libs.v0.upgrade import (
     build_complete_sem_ver,
     verify_caret_requirements,
     verify_tilde_requirements,
+    verify_wildcard_requirements,
 )
 
 
@@ -93,3 +94,31 @@ def test_verify_caret_requirements(requirement, version, output):
 )
 def test_verify_tilde_requirements(requirement, version, output):
     assert verify_tilde_requirements(version=version, requirement=requirement) == output
+
+@pytest.mark.parametrize(
+    "requirement,version,output",
+    [
+        ("~1", "1", True),
+        ("^0", "1", True),
+        ("0", "0.1", True),
+        ("*", "1.5.6", True),
+        ("*", "0.0.1", True),
+        ("*", "0.2.0", True),
+        ("*", "1.0.0", True),
+        ("1.*", "1.0.0", True),
+        ("1.*", "2.0.0", False),
+        ("1.*", "0.6.2", False),
+        ("1.2.*", "0.6.2", False),
+        ("1.2.*", "1.6.2", False),
+        ("1.2.*", "1.2.2", True),
+        ("1.2.*", "1.2.0", True),
+        ("1.2.*", "1.1.6", False),
+        ("1.2.*", "1.1.0", False),
+        ("0.2.*", "1.1.0", False),
+        ("0.2.*", "0.1.0", False),
+        ("0.2.*", "0.2.9", True),
+        ("0.2.*", "0.6.0", False),
+    ],
+)
+def test_verify_wildcard_requirements(requirement, version, output):
+    assert verify_wildcard_requirements(version=version, requirement=requirement) == output

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -1,0 +1,62 @@
+import logging
+import pytest
+from charms.data_platform_libs.v0.upgrade import (
+    reduce_versions,
+    build_complete_sem_ver,
+    verify_caret_requirements,
+    verify_tilde_requirements,
+)
+
+
+@pytest.mark.parametrize(
+    "version,output", [("0.0.24.0.4", "24.0.4"), ("3.5.3", "3.5.3"), ("0.3", "3")]
+)
+def test_reduce_versions(version, output):
+    assert reduce_versions(version) == output
+
+
+@pytest.mark.parametrize(
+    "version,output",
+    [
+        ("0.0.24.0.4", [0, 0, 24]),
+        ("3.5.3", [3, 5, 3]),
+        ("0.3", [0, 3, 0]),
+        ("1.2", [1, 2, 0]),
+        (1, [1, 0, 0]),
+    ],
+)
+def test_build_complete_sem_ver(version, output):
+    assert build_complete_sem_ver(version) == output
+
+@pytest.mark.parametrize(
+    "requirement,version,output",
+    [
+        ("^1.2.3", "1.2.2", False),
+        ("^1.2.3", "1.3", True),
+        ("^1.2.3", "2.2.5", False),
+        ("^1.2", "1.2.2", True),
+        ("^1.2.3", "1.2", False),
+        ("^1.2.3", "2.2.5", False),
+        ("^1", "1.2.2", True),
+        ("^1", "1.6", True),
+        ("^1", "1.7.9", True),
+        ("^1", "0.6", False),
+        ("^1", "2", False),
+        ("^1", "2.3", False),
+        ("^0.2.3", "0.2.2", False),
+        ("^0.2.3", "0.2.5", True),
+        ("^0.2.3", "1.2.5", False),
+        ("^0.2.3", "0.3.6", False),
+        ("^0.0.3", "0.0.4", False),
+        ("^0.0.3", "0.0.2", False),
+        ("^0.0.3", "0.0", False),
+        ("^0.0.3", "0.3.6", False),
+        ("^0.0", "0.0.3", True),
+        ("^0.0", "0.1.0", False),
+        ("^0", "0.1.0", True),
+        ("^0", "0.3.6", True),
+        ("^0", "1.0.0", False),
+    ],
+)
+def test_verify_caret_requirements(requirement, version, output):
+    assert verify_caret_requirements(version=version, requirement=requirement) == output

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -14,6 +14,10 @@ from charms.data_platform_libs.v0.upgrade import (
 from pydantic import ValidationError
 
 
+class GandalfModel(BaseModel):
+    gandalf_the_white: DependencyModel
+
+
 @pytest.mark.parametrize(
     "version,output",
     [
@@ -190,9 +194,6 @@ def test_dependency_model_raises_for_incompatible_version():
         },
     }
 
-    class GandalfModel(BaseModel):
-        gandalf_the_white: DependencyModel
-
     with pytest.raises(ValidationError):
         GandalfModel(**deps)
 
@@ -207,9 +208,6 @@ def test_dependency_model_raises_for_bad_dependency(value):
             "version": "7",
         },
     }
-
-    class GandalfModel(BaseModel):
-        gandalf_the_white: DependencyModel
 
     with pytest.raises(ValidationError):
         GandalfModel(**deps)
@@ -226,9 +224,6 @@ def test_dependency_model_raises_for_bad_nested_dependency(value):
         },
     }
 
-    class GandalfModel(BaseModel):
-        gandalf_the_white: DependencyModel
-
     with pytest.raises(ValidationError):
         GandalfModel(**deps)
 
@@ -244,9 +239,6 @@ def test_dependency_model_raises_for_bad_upgrade_supported(value):
         },
     }
 
-    class GandalfModel(BaseModel):
-        gandalf_the_white: DependencyModel
-
     with pytest.raises(ValidationError):
         GandalfModel(**deps)
 
@@ -261,10 +253,8 @@ def test_dependency_model_succeeds():
         },
     }
 
-    class GandalfModel(BaseModel):
-        gandalf_the_white: DependencyModel
-
     GandalfModel(**deps)
+
 
 def test_dependency_model_succeeds_nested():
     deps = {
@@ -275,8 +265,5 @@ def test_dependency_model_succeeds_nested():
             "version": "7",
         },
     }
-
-    class GandalfModel(BaseModel):
-        gandalf_the_white: DependencyModel
 
     GandalfModel(**deps)

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 import pytest
 from charms.data_platform_libs.v0.upgrade import (
     build_complete_sem_ver,


### PR DESCRIPTION
## Changes Made
##### `feat: add dependency conflict validators`
- `build_complete_sem_ver()` converts string versions into full major.minor.patch semantic versions, padding with 0s where not specified
    - etc `1.3` --> `[1, 3, 0]`
- All verification functions called in `verify_inequality_requirements` wrapper, returning boolean if passed arg version meets passed arg requirement
- Involved functions support version definition specification used by [`poetry`](https://python-poetry.org/docs/dependency-specification/), supporting:
    - [Caret](https://python-poetry.org/docs/dependency-specification/#caret-requirements)
    - [Tilde](https://python-poetry.org/docs/dependency-specification/#tilde-requirements)
    - [Wildcard](https://python-poetry.org/docs/dependency-specification/#wildcard-requirements)
    - [Inequality](https://python-poetry.org/docs/dependency-specification/#inequality-requirements)
        - NOTE - Choosing to support only `>` and `>=` for the time being, as an 'upgrade' implies increasing in version
##### `feat: strict typing of input dependencies with DependencyModel`
- Charm authors can define a dict of arbitrarily named keys in their charm with value of the dependencies for the current version of the charm, passing it in to the constructor of `DataUpgrade`
- The Pydantic model evaluates these specified dependencies for compliance to the above-mentioned specification, and whether specified `version` is compatible with specified `upgrade_supported`
- **REVIEW NOTE** - Idea is to load back the persisted dependencies dict from relation data into the same type as the defined model, and use something like:
    ```python
    if not old_deps >> new_deps:
        raise
    ```
    - Use of the bitshift operator is fairly weird, but I thought it was actually quite a nice override, very much welcome opinions here
##### `feat: custom Exceptions for various failure cases`
- `UpgradeError` base-class
- `ClusterNotReadyError` to be raised during `pre_upgrade_check()` by charm authors
- `UpgradeFailedError` to be raised during `upgrade_granted_event()` handlers by charm authors
##### `feat: DataUpgrade object for handling and emitting of upgrade events`
- Persists charm-author passed `dependencies` to relation data during `upgrade-relation-created` handler 
- Exposes properties for use by charm authors for `state`, `stored_dependencies`, `upgrade_stack`
- Abstractmethods for `pre_upgrade_check` and `build_upgrade_stack`, to be overridden by charm authors
- `pre_upgrade_check` handler does the following:
    - Fails if not leader
    - Fails if **ANY** unit is already in the process of upgrading (by checking `state`)
    - Runs charm-author defined `pre_upgrade_check`
    - Runs charm-author defined `build_upgrade_stack`, writing it to relation data
    - Sets all units to `state=waiting`
##### `style: add ruff`
- Basic ruff `pyproject.toml` specification, in preparation for a future PR to this repo to replace `flake8` for all libraries