### PR TITLE
[DPE-1928] Validate wildcard topic on KafkaRequires

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tests/integration/application-s3-charm/lib/charms/data_platform_libs/v0/s3.py
 tests/integration/database-charm/lib/charms/data_platform_libs/v0/data_interfaces.py
 tests/integration/kafka-charm/lib/charms/data_platform_libs/v0/data_interfaces.py
 tests/integration/s3-charm/lib/charms/data_platform_libs/v0/s3.py'
+.vscode/

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -316,7 +316,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 12
+LIBPATCH = 13
 
 PYDEPS = ["ops>=2.0.0"]
 
@@ -1199,6 +1199,18 @@ class KafkaRequires(DataRequires):
         self.charm = charm
         self.topic = topic
         self.consumer_group_prefix = consumer_group_prefix or ""
+
+    @property
+    def topic(self):
+        """Topic to use in Kafka."""
+        return self._topic
+
+    @topic.setter
+    def topic(self, value):
+        # Avoid wildcards
+        if value == "*":
+            raise ValueError(f"Error on topic '{value}', cannot be a wildcard.")
+        self._topic = value
 
     def _on_relation_joined_event(self, event: RelationJoinedEvent) -> None:
         """Event emitted when the application joins the Kafka relation."""

--- a/tests/unit/test_data_interfaces.py
+++ b/tests/unit/test_data_interfaces.py
@@ -44,6 +44,7 @@ provides:
 """
 
 TOPIC = "data_platform_topic"
+WILDCARD_TOPIC = "*"
 KAFKA_RELATION_INTERFACE = "kafka_client"
 KAFKA_RELATION_NAME = "kafka"
 KAFKA_METADATA = f"""
@@ -1150,6 +1151,11 @@ class TestKafkaRequires(DataRequirerBaseTests, unittest.TestCase):
 
         # Assert the hook is called now.
         _on_bootstrap_server_changed.assert_called_once()
+
+    def test_wildcard_topic(self):
+        """Asserts Exception raised on wildcard being used for topic."""
+        with self.assertRaises(ValueError):
+            self.harness.charm.requirer.topic = WILDCARD_TOPIC
 
     def test_additional_fields_are_accessible(self):
         """Asserts additional fields are accessible using the charm library after being set."""


### PR DESCRIPTION
Adds basic validation to avoid topic wildcards on Kafka.