### PR TITLE
DPE-2218 Better handling of broken s3 relation

### DIFF
--- a/lib/charms/data_platform_libs/v0/s3.py
+++ b/lib/charms/data_platform_libs/v0/s3.py
@@ -752,11 +752,11 @@ class S3Requirer(Object):
 
     def get_s3_connection_info(self) -> Dict[str, str]:
         """Return the s3 credentials as a dictionary."""
-        relation = self.charm.model.get_relation(self.relation_name)
-        if not relation or not relation.app:
-            return {}
+        for relation in self.relations:
+            if relation and relation.app:
+                return self._load_relation_data(relation.data[relation.app])
 
-        return self._load_relation_data(relation.data[relation.app])
+        return {}
 
     def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Notify the charm about a broken S3 credential store relation."""

--- a/lib/charms/data_platform_libs/v0/s3.py
+++ b/lib/charms/data_platform_libs/v0/s3.py
@@ -137,7 +137,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
from bug report https://github.com/canonical/postgresql-operator/issues/180 by @kian99 

> Hey folks, a relation problem. I've deployed Postgresql from 14/stable. I related it to another charm "s3-integrator" that provides it with config for communicating with an S3 bucket. I then removed the relation with --force and went through the process of adding and removing the relation a few times as I worked on some firewall issues.
> 
> Now i'm facing an issue where Postrgres thinks the s3-integrator charm is still related (see below) and further operations are failing because of some checks in the charm expecting only a single relation. 
> $ juju exec --unit postgresql/0 -- relation-ids s3-parameters
> s3-parameters:13
> s3-parameters:14

