### PR TITLE
fix: various bugs

### DIFF
--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -593,16 +593,14 @@ class DataUpgrade(Object, ABC):
             event.defer()
             return
 
-        logger.info("Setting upgrade state to idle...")
+        # setting initial idle state needed to avoid execution on upgrade-changed events
         self.peer_relation.data[self.charm.unit].update({"state": "idle"})
 
-        if not self.charm.unit.is_leader():
-            return
-
-        logger.info("Setting charm dependencies to relation data...")
-        self.peer_relation.data[self.charm.app].update(
-            {"dependencies": json.dumps(self.dependency_model.dict())}
-        )
+        if self.charm.unit.is_leader():
+            logger.debug("Persisting dependencies to upgrade relation data...")
+            self.peer_relation.data[self.charm.app].update(
+                {"dependencies": json.dumps(self.dependency_model.dict())}
+            )
 
     def _on_pre_upgrade_check_action(self, event: ActionEvent) -> None:
         """Handler for `pre-upgrade-check-action` events."""

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -739,7 +739,7 @@ class DataUpgrade(Object, ABC):
 
         # pop mutates the `upgrade_stack` attr
         top_unit_id = self.upgrade_stack.pop()
-        top_unit = self.charm.model.get_unit(f"{self.charm.app}/{top_unit_id}")
+        top_unit = self.charm.model.get_unit(f"{self.charm.app.name}/{top_unit_id}")
         top_state = self.peer_relation.data[top_unit].get("state")
 
         # if top of stack is completed, leader pops it

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -708,7 +708,7 @@ class DataUpgrade(Object, ABC):
         # all units sets state to ready
         self.peer_relation.data[self.charm.unit].update({"state": "ready"})
 
-    def on_upgrade_changed(self, event: RelationChangedEvent) -> None:
+    def on_upgrade_changed(self, event: EventBase) -> None:
         """Handler for `upgrade-relation-changed` events."""
         if not self.peer_relation:
             return

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -726,6 +726,8 @@ class DataUpgrade(Object, ABC):
                 logger.info("All units completed upgrade, setting idle upgrade state...")
                 self.peer_relation.data[self.charm.unit].update({"state": "idle"})
                 return
+            elif self.cluster_state == "idle":
+                return
             else:  # in case event was handled before pre-checks
                 logger.debug("Did not find upgrade-stack or completed cluster state, deferring...")
                 event.defer()

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -23,7 +23,6 @@ from ops.charm import (
     ActionEvent,
     CharmBase,
     CharmEvents,
-    RelationChangedEvent,
     RelationCreatedEvent,
     UpgradeCharmEvent,
 )
@@ -496,7 +495,7 @@ class DataUpgrade(Object, ABC):
             return None
 
         # lazy-load
-        if not self._upgrade_stack:
+        if self._upgrade_stack is None:
             self._upgrade_stack = (
                 json.loads(self.peer_relation.data[self.charm.app].get("upgrade-stack", "[]"))
                 or None

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -745,9 +745,7 @@ class DataUpgrade(Object, ABC):
 
             # writes the mutated attr back to rel data
             self.peer_relation.data[self.charm.app].update(
-                {
-                    "upgrade-stack": json.dumps(self.upgrade_stack)
-                }
+                {"upgrade-stack": json.dumps(self.upgrade_stack)}
             )
 
             # recurse on leader to ensure relation changed event not lost

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -432,6 +432,7 @@ class DataUpgrade(Object, ABC):
         self.dependency_model = dependency_model
         self.relation_name = relation_name
         self.substrate = substrate
+        self._upgrade_stack = None
 
         # events
         self.framework.observe(

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -39,7 +39,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 PYDEPS = ["pydantic>=1.10,<2"]
 

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -590,11 +590,14 @@ class DataUpgrade(Object, ABC):
 
     def _on_upgrade_created(self, event: RelationCreatedEvent) -> None:
         """Handler for `upgrade-relation-created` events."""
-        if not self.charm.unit.is_leader():
-            return
-
         if not self.peer_relation:
             event.defer()
+            return
+
+        logger.info("Setting upgrade state to idle...")
+        self.peer_relation.data[self.charm.unit].update({"state": "idle"})
+
+        if not self.charm.unit.is_leader():
             return
 
         logger.info("Setting charm dependencies to relation data...")

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -722,13 +722,14 @@ class DataUpgrade(Object, ABC):
 
         # if all units completed, mark as complete
         if not self.upgrade_stack:
-            if self.cluster_state == "completed":
+            if self.cluster_state == "idle":
+                logger.debug("upgrade-changed event handled before pre-checks, exiting...")
+                return
+            elif self.cluster_state == "completed":
                 logger.info("All units completed upgrade, setting idle upgrade state...")
                 self.peer_relation.data[self.charm.unit].update({"state": "idle"})
                 return
-            elif self.cluster_state == "idle":
-                return
-            else:  # in case event was handled before pre-checks
+            else:
                 logger.debug("Did not find upgrade-stack or completed cluster state, deferring...")
                 event.defer()
                 return


### PR DESCRIPTION
## Changes Made
#### `fix: avoid recursion limit errors on leader`
- `[]` and `None` are both falsey in Python. When the final unit had been popped from the list, we would attempt to set that empty list to relation data by referencing the property. The property checks for `if not X: fetch`, getting the un-popped value from the relation data
- When we recursed on the leader, we'd get recursion limit errors, as it would never exit due to it just re-setting the original stack
- Fixed by specifically checking for `if self._upgrade_stack is None`
#### `fix: actually set default idle state on relation created`
- When unset, we'd handle relation events before upgrades had progressed
- Fixed, now we can check for `idle` and exit
