### PR TITLE
DPE-2288 - feat: support rollbacks, add statuses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ tests/integration/database-charm/lib/charms/data_platform_libs/v0/data_interface
 tests/integration/kafka-charm/lib/charms/data_platform_libs/v0/data_interfaces.py
 tests/integration/s3-charm/lib/charms/data_platform_libs/v0/s3.py'
 .vscode/
+.idea/

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -353,6 +353,21 @@ class ClusterNotReadyError(UpgradeError):
         super().__init__(message, cause=cause, resolution=resolution)
 
 
+class KubernetesClientError(UpgradeError):
+    """Exception flagging that a call to Kubernetes API failed.
+
+    For example, if the cluster fails :class:`DataUpgrade._set_rolling_update_partition`
+
+    Args:
+        message: string message to be logged out
+        cause: short human-readable description of the cause of the error
+        resolution: short human-readable instructions for manual error resolution (optional)
+    """
+
+    def __init__(self, message: str, cause: str, resolution: Optional[str] = None):
+        super().__init__(message, cause=cause, resolution=resolution)
+
+
 class VersionError(UpgradeError):
     """Exception flagging that the old `version` fails to meet the new `upgrade_supported`s.
 
@@ -400,6 +415,10 @@ class UpgradeGrantedEvent(EventBase):
     """
 
 
+class UpgradeFinishedEvent(EventBase):
+    """Used to tell units that they finished the upgrade."""
+
+
 class UpgradeEvents(CharmEvents):
     """Upgrade events.
 
@@ -407,6 +426,7 @@ class UpgradeEvents(CharmEvents):
     """
 
     upgrade_granted = EventSource(UpgradeGrantedEvent)
+    upgrade_finished = EventSource(UpgradeFinishedEvent)
 
 
 # --- EVENT HANDLER ---
@@ -442,11 +462,16 @@ class DataUpgrade(Object, ABC):
         )
         self.framework.observe(self.charm.on.upgrade_charm, self._on_upgrade_charm)
         self.framework.observe(getattr(self.on, "upgrade_granted"), self._on_upgrade_granted)
+        self.framework.observe(getattr(self.on, "upgrade_finished"), self._on_upgrade_finished)
 
         # actions
         self.framework.observe(
             getattr(self.charm.on, "pre_upgrade_check_action"), self._on_pre_upgrade_check_action
         )
+        if self.substrate == "k8s":
+            self.framework.observe(
+                getattr(self.charm.on, "resume_upgrade_action"), self._on_resume_upgrade_action
+            )
 
     @property
     def peer_relation(self) -> Optional[Relation]:
@@ -518,6 +543,18 @@ class DataUpgrade(Object, ABC):
         self._upgrade_stack = stack
 
     @property
+    def unit_states(self) -> list:
+        """Current upgrade state for all units.
+
+        Returns:
+            Unsorted list of upgrade states for all units.
+        """
+        if not self.peer_relation:
+            return []
+
+        return [self.peer_relation.data[unit].get("state", "") for unit in self.app_units]
+
+    @property
     def cluster_state(self) -> Optional[str]:
         """Current upgrade state for cluster units.
 
@@ -529,13 +566,11 @@ class DataUpgrade(Object, ABC):
         Returns:
             String of upgrade state from the furthest behind unit.
         """
-        if not self.peer_relation:
+        if not self.unit_states:
             return None
 
-        states = [self.peer_relation.data[unit].get("state", "") for unit in self.app_units]
-
         try:
-            return sorted(states, key=self.STATES.index)[0]
+            return sorted(self.unit_states, key=self.STATES.index)[0]
         except (ValueError, KeyError):
             return None
 
@@ -556,7 +591,7 @@ class DataUpgrade(Object, ABC):
         Called by leader unit during :meth:`_on_pre_upgrade_check_action`.
 
         Returns:
-            Iterable of integeter unit.ids, LIFO ordered in upgrade order
+            Iterable of integer unit.ids, LIFO ordered in upgrade order
                 i.e `[5, 2, 4, 1, 3]`, unit `3` upgrades first, `5` upgrades last
         """
         # don't raise if k8s substrate, uses default statefulset order
@@ -628,6 +663,13 @@ class DataUpgrade(Object, ABC):
         self.charm.unit.status = MaintenanceStatus("upgrade completed")
         self.peer_relation.data[self.charm.unit].update({"state": "completed"})
 
+        # Emit upgrade_finished event to run unit's post upgrade operations.
+        if self.substrate == "k8s":
+            logger.debug(
+                f"{self.charm.unit.name} has completed the upgrade, emitting `upgrade_finished` event..."
+            )
+            getattr(self.on, "upgrade_finished").emit()
+
     def _on_upgrade_created(self, event: RelationCreatedEvent) -> None:
         """Handler for `upgrade-relation-created` events."""
         if not self.peer_relation:
@@ -692,6 +734,37 @@ class DataUpgrade(Object, ABC):
         logger.info("Setting upgrade-stack to relation data...")
         self.upgrade_stack = built_upgrade_stack
 
+    def _on_resume_upgrade_action(self, event: ActionEvent) -> None:
+        """Handle resume upgrade action.
+
+        Continue the upgrade by setting the partition to the next unit.
+        """
+        if not self.peer_relation:
+            event.fail(message="Could not find upgrade relation.")
+            return
+
+        if not self.charm.unit.is_leader():
+            event.fail(message="Action must be ran on the Juju leader.")
+            return
+
+        if not self.upgrade_stack:
+            event.fail(message="Nothing to resume, upgrade stack unset.")
+            return
+
+        # Check whether this is being run after juju refresh was called
+        # (the size of the upgrade stack should match the number of total
+        # unit minus one).
+        if len(self.upgrade_stack) != len(self.peer_relation.units):
+            event.fail(message="Upgrade can be resumed only once after juju refresh is called.")
+            return
+
+        try:
+            next_partition = self.upgrade_stack[-1]
+            self._set_rolling_update_partition(partition=next_partition)
+            event.set_results({"message": f"Upgrade will resume on unit {next_partition}"})
+        except KubernetesClientError:
+            event.fail(message="Cannot set rolling update partition.")
+
     def _upgrade_supported_check(self) -> None:
         """Checks if previous versions can be upgraded to new versions.
 
@@ -737,18 +810,33 @@ class DataUpgrade(Object, ABC):
             logger.error("Cluster upgrade failed, ensure pre-upgrade checks are ran first.")
             return
 
-        # run version checks on leader only
-        if self.charm.unit.is_leader():
-            try:
-                self._upgrade_supported_check()
-            except VersionError as e:  # not ready if not passed check
-                logger.error(e)
-                self.set_unit_failed()
-                return
+        if self.substrate == "vm":
+            # for VM run version checks on leader only
+            if self.charm.unit.is_leader():
+                try:
+                    self._upgrade_supported_check()
+                except VersionError as e:  # not ready if not passed check
+                    logger.error(e)
+                    self.set_unit_failed()
+                    return
+            self.charm.unit.status = WaitingStatus("other units upgrading first...")
+            self.peer_relation.data[self.charm.unit].update({"state": "ready"})
 
-        # all units sets state to ready
-        self.charm.unit.status = WaitingStatus("other units upgrading first...")
-        self.peer_relation.data[self.charm.unit].update({"state": "ready"})
+        else:
+            # for k8s run version checks only on highest ordinal unit
+            if (
+                self.charm.unit.name
+                == f"{self.charm.app.name}/{self.charm.app.planned_units() -1}"
+            ):
+                try:
+                    self._upgrade_supported_check()
+                except VersionError as e:  # not ready if not passed check
+                    logger.error(e)
+                    self.set_unit_failed()
+                    return
+            # On K8s an unit that receives the upgrade-charm event is upgrading
+            self.charm.unit.status = MaintenanceStatus("upgrading unit")
+            self.peer_relation.data[self.charm.unit].update({"state": "upgrading"})
 
     def on_upgrade_changed(self, event: EventBase) -> None:
         """Handler for `upgrade-relation-changed` events."""
@@ -779,6 +867,10 @@ class DataUpgrade(Object, ABC):
                 logger.debug("Did not find upgrade-stack or completed cluster state, deferring...")
                 event.defer()
                 return
+        else:
+            # upgrade ongoing, set status for waiting units
+            if "upgrading" in self.unit_states and self.state in ["idle", "ready"]:
+                self.charm.unit.status = WaitingStatus("other units upgrading first...")
 
         # pop mutates the `upgrade_stack` attr
         top_unit_id = self.upgrade_stack.pop()
@@ -805,12 +897,81 @@ class DataUpgrade(Object, ABC):
             and self.cluster_state == "ready"
         ):
             logger.debug(
-                f"{top_unit} is next to upgrade, emitting `upgrade_granted` event and upgrading..."
+                f"{top_unit.name} is next to upgrade, emitting `upgrade_granted` event and upgrading..."
             )
             self.charm.unit.status = MaintenanceStatus("upgrading...")
             self.peer_relation.data[self.charm.unit].update({"state": "upgrading"})
             getattr(self.on, "upgrade_granted").emit()
 
-    @abstractmethod
     def _on_upgrade_granted(self, event: UpgradeGrantedEvent) -> None:
         """Handler for `upgrade-granted` events."""
+        # don't raise if k8s substrate, only return
+        if self.substrate == "k8s":
+            return
+
+        raise NotImplementedError
+
+    def _on_upgrade_finished(self, _) -> None:
+        """Handler for `upgrade-finished` events."""
+        if self.substrate == "vm" or not self.peer_relation:
+            return
+
+        # Emit the upgrade relation changed event in the leader to update the upgrade_stack.
+        if self.charm.unit.is_leader():
+            self.charm.on[self.relation_name].relation_changed.emit(
+                self.model.get_relation(self.relation_name)
+            )
+
+        # This hook shouldn't run for the last unit (the first that is upgraded). For that unit it
+        # should be done through an action after the upgrade success on that unit is double-checked.
+        unit_number = int(self.charm.unit.name.split("/")[1])
+        if unit_number == len(self.peer_relation.units):
+            logger.info(
+                f"{self.charm.unit.name} unit upgraded. Evaluate and run `resume-upgrade` action to continue upgrade"
+            )
+            return
+
+        # Also, the hook shouldn't run for the first unit (the last that is upgraded).
+        if unit_number == 0:
+            logger.info(f"{self.charm.unit.name} unit upgraded. Upgrade is complete")
+            return
+
+        try:
+            # Use the unit number instead of the upgrade stack to avoid race conditions
+            # (i.e. the leader updates the upgrade stack after this hook runs).
+            next_partition = unit_number - 1
+            logger.debug(f"Set rolling update partition to unit {next_partition}")
+            self._set_rolling_update_partition(partition=next_partition)
+        except KubernetesClientError:
+            logger.exception("Cannot set rolling update partition")
+            self.set_unit_failed()
+            self.log_rollback_instructions()
+
+    def _set_rolling_update_partition(self, partition: int) -> None:
+        """Patch the StatefulSet's `spec.updateStrategy.rollingUpdate.partition`.
+
+        Args:
+            partition: partition to set.
+
+        K8s only. It should decrement the rolling update strategy partition by using a code
+        like the following:
+
+            from lightkube.core.client import Client
+            from lightkube.core.exceptions import ApiError
+            from lightkube.resources.apps_v1 import StatefulSet
+
+            try:
+                patch = {"spec": {"updateStrategy": {"rollingUpdate": {"partition": partition}}}}
+                Client().patch(StatefulSet, name=self.charm.model.app.name, namespace=self.charm.model.name, obj=patch)
+                logger.debug(f"Kubernetes StatefulSet partition set to {partition}")
+            except ApiError as e:
+                if e.status.code == 403:
+                    cause = "`juju trust` needed"
+                else:
+                    cause = str(e)
+                raise KubernetesClientError("Kubernetes StatefulSet patch failed", cause)
+        """
+        if self.substrate == "vm":
+            return
+
+        raise NotImplementedError

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -6,6 +6,8 @@ import logging
 
 import pytest
 from ops.charm import CharmBase
+from ops.framework import EventBase
+from ops.model import BlockedStatus
 from ops.testing import Harness
 from pydantic import ValidationError
 
@@ -403,17 +405,21 @@ def test_build_upgrade_stack_succeeds_k8s(harness):
     gandalf.build_upgrade_stack()
 
 
-def test_set_unit_failed_resets_stack(harness):
+def test_set_unit_failed_resets_stack(harness, mocker):
     gandalf = GandalfUpgrade(charm=harness.charm, dependency_model=GandalfModel, substrate="k8s")
     harness.add_relation("upgrade", "gandalf")
     gandalf._upgrade_stack = ["1", "2", "3"]
     harness.set_leader(True)
+    log_spy = mocker.spy(GandalfUpgrade, "log_rollback_instructions")
 
     assert gandalf._upgrade_stack
 
     gandalf.set_unit_failed()
 
     assert not gandalf._upgrade_stack
+
+    assert isinstance(harness.charm.unit.status, BlockedStatus)
+    assert log_spy.call_count == 1
 
 
 def test_set_unit_completed_resets_stack(harness):
@@ -542,6 +548,26 @@ def test_pre_upgrade_check_action_builds_upgrade_stack_k8s(harness, mocker):
     assert json.loads(relation_stack) == [0, 1]
 
 
+def test_pre_upgrade_check_recovers_stack(harness, mocker):
+    gandalf_model = GandalfModel(**GANDALF_DEPS)
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=gandalf_model, substrate="k8s"
+    )
+    harness.add_relation("upgrade", "gandalf")
+
+    mocker.patch.object(GandalfUpgrade, "_repair_upgrade_stack")
+
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "failed"})
+    harness.set_leader(True)
+
+    mock_event = mocker.MagicMock()
+    harness.charm.upgrade._on_pre_upgrade_check_action(mock_event)
+
+    GandalfUpgrade._repair_upgrade_stack.assert_called_once()
+    assert isinstance(harness.charm.unit.status, BlockedStatus)
+    assert harness.charm.upgrade.state == "recovery"
+
+
 def test_upgrade_suppported_check_fails(harness):
     bad_deps = {
         "gandalf_the_white": {
@@ -587,33 +613,6 @@ def test_upgrade_suppported_check_succeeds(harness):
     harness.charm.upgrade._upgrade_supported_check()
 
 
-def test_upgrade_charm_sets_failed_and_logs(harness, mocker):
-    harness.charm.upgrade = GandalfUpgrade(
-        charm=harness.charm, dependency_model=GandalfModel(**GANDALF_DEPS), substrate="k8s"
-    )
-    harness.add_relation("upgrade", "gandalf")
-
-    # if not upgrade stack
-    mocker.patch.object(harness.charm.upgrade, "log_rollback_instructions")
-    mocker.patch.object(harness.charm.upgrade, "set_unit_failed")
-    harness.charm.on.upgrade_charm.emit()
-
-    harness.charm.upgrade.log_rollback_instructions.assert_called_once()
-    harness.charm.upgrade.set_unit_failed.assert_called_once()
-
-    # if cluster state failed
-    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "failed"})
-    harness.charm.upgrade.upgrade_stack = [0]
-
-    mocker.patch.object(harness.charm.upgrade, "log_rollback_instructions")
-    mocker.patch.object(harness.charm.upgrade, "set_unit_failed")
-
-    harness.charm.on.upgrade_charm.emit()
-
-    harness.charm.upgrade.log_rollback_instructions.assert_called_once()
-    harness.charm.upgrade.set_unit_failed.assert_called_once()
-
-
 def test_upgrade_charm_runs_checks_on_leader(harness, mocker):
     harness.charm.upgrade = GandalfUpgrade(
         charm=harness.charm, dependency_model=GandalfModel(**GANDALF_DEPS), substrate="k8s"
@@ -648,24 +647,22 @@ def test_upgrade_charm_sets_ready(harness, mocker):
     assert harness.charm.upgrade.state == "ready"
 
 
-def test_upgrade_changed_fails_unit_if_any_failed(harness, mocker):
+def test_upgrade_changed_defers_if_recovery(harness, mocker):
     harness.charm.upgrade = GandalfUpgrade(
         charm=harness.charm, dependency_model=GandalfModel(**GANDALF_DEPS), substrate="k8s"
     )
     harness.add_relation("upgrade", "gandalf")
-    harness.charm.upgrade.upgrade_stack = [0]
-    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "completed"})
-    harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/1")
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "recovery"})
 
-    mocker.patch.object(harness.charm.upgrade, "log_rollback_instructions")
-    mocker.patch.object(harness.charm.upgrade, "set_unit_failed")
+    with harness.hooks_disabled():
+        harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/1")
 
+    defer_spy = mocker.spy(EventBase, "defer")
     harness.update_relation_data(
         harness.charm.upgrade.peer_relation.id, "gandalf/1", {"state": "failed"}
     )
 
-    harness.charm.upgrade.log_rollback_instructions.assert_called_once()
-    harness.charm.upgrade.set_unit_failed.assert_called_once()
+    assert defer_spy.call_count == 1
 
 
 def test_upgrade_changed_sets_idle_if_all_completed(harness):
@@ -748,6 +745,27 @@ def test_upgrade_changed_emits_upgrade_granted_only_if_top_of_stack(
     assert harness.charm.upgrade.state == post_state
 
 
+def test_upgrade_changed_emits_upgrade_granted_only_if_all_ready(harness, mocker):
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=GandalfModel(**GANDALF_DEPS), substrate="k8s"
+    )
+
+    with harness.hooks_disabled():
+        harness.add_relation("upgrade", "gandalf")
+        harness.charm.upgrade.upgrade_stack = [1, 0]
+        harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/1")
+        harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "ready"})
+
+    upgrade_granted_spy = mocker.spy(harness.charm.upgrade, "_on_upgrade_granted")
+
+    harness.update_relation_data(
+        harness.charm.upgrade.peer_relation.id, "gandalf/1", {"state": "idle"}
+    )
+
+    assert upgrade_granted_spy.call_count == 0
+    assert harness.charm.upgrade.state == "ready"
+
+
 def test_upgrade_changed_recurses_on_leader_and_clears_stack(harness, mocker):
     harness.charm.upgrade = GandalfUpgrade(
         charm=harness.charm, dependency_model=GandalfModel(**GANDALF_DEPS), substrate="k8s"
@@ -792,3 +810,51 @@ def test_upgrade_changed_does_not_recurse_or_change_stack_non_leader(harness, mo
     assert json.loads(
         harness.charm.upgrade.peer_relation.data[harness.charm.app].get("upgrade-stack", "")
     ) == [0, 1]
+
+
+def test_repair_upgrade_stack_puts_failed_unit_first_in_stack(harness):
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=GandalfModel(**GANDALF_DEPS), substrate="k8s"
+    )
+    harness.add_relation("upgrade", "gandalf")
+    harness.charm.upgrade.upgrade_stack = [0, 2]
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "ready"})
+    harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/1")
+    harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/2")
+    harness.set_leader(True)
+
+    with harness.hooks_disabled():
+        harness.update_relation_data(
+            harness.charm.upgrade.peer_relation.id, "gandalf/1", {"state": "completed"}
+        )
+        harness.update_relation_data(
+            harness.charm.upgrade.peer_relation.id, "gandalf/2", {"state": "failed"}
+        )
+
+    harness.charm.upgrade._repair_upgrade_stack()
+
+    assert harness.charm.upgrade.upgrade_stack == [0, 1, 2]
+
+
+def test_repair_upgrade_stack_does_not_modify_existing_stack(harness):
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=GandalfModel(**GANDALF_DEPS), substrate="k8s"
+    )
+    harness.add_relation("upgrade", "gandalf")
+    harness.charm.upgrade.upgrade_stack = [0, 2, 1]
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "ready"})
+    harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/1")
+    harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/2")
+    harness.set_leader(True)
+
+    with harness.hooks_disabled():
+        harness.update_relation_data(
+            harness.charm.upgrade.peer_relation.id, "gandalf/1", {"state": "failed"}
+        )
+        harness.update_relation_data(
+            harness.charm.upgrade.peer_relation.id, "gandalf/2", {"state": "ready"}
+        )
+
+    harness.charm.upgrade._repair_upgrade_stack()
+
+    assert harness.charm.upgrade.upgrade_stack == [0, 2, 1]


### PR DESCRIPTION
## Changes Made
#### `feat: support managed rollback after failed upgrade`
- Units now stay in the same state they were before failing, not also failing
- Running `pre-upgrade-check` action after a cluster has failed sets `state=recovering` to the leader
- `upgrade-charm` modifies upgrade-stack to insert any units that were already popped + completed (i.e not the failed ones)
    - Failed units are inserted to the top of the existing stack 
- `upgrade-granted` now only emitted when all units are ready

#### `feat: add unit statuses during upgrade`
- `BlockedStatus` with optional `cause` passed by `set_unit_failed()` if unit fails during
- `BlockedStatus` with generic message if any other unit failed during
- `MaintenanceStatus` throughout
- `ActiveStatus` when setting back to `state=idle`