### PR TITLE
refactor: unify k8s+vm upgrade pattern

### DIFF
--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -1110,7 +1110,13 @@ class DataUpgrade(Object, ABC):
                 if self.charm.unit.is_leader():
                     logger.debug("Persisting new dependencies to upgrade relation data...")
                     self.peer_relation.data[self.charm.app].update(
-                        {"dependencies": json.dumps(self.dependency_model.dict())}
+                        {
+                            "dependencies": json.dumps(
+                                self.dependency_model.dict()
+                            ),  # persisting new deps
+                            "resume-strategy": "",  # resetting resume-strategy for future upgrades
+                            "upgrade-stack": "",  # resetting upgrade-stack for future upgrades
+                        }
                     )
                 return
 

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -925,6 +925,11 @@ class DataUpgrade(Object, ABC):
         # now leader pulls a fresh stack from newly updated relation data
         if self.charm.unit.is_leader():
             self._upgrade_stack = None
+            # recurse on leader to ensure relation changed event not lost
+            # in case leader is next or the last unit to complete
+            self.charm.on[self.relation_name].relation_changed.emit(
+                self.model.get_relation(self.relation_name)
+            )
 
         self.charm.unit.status = MaintenanceStatus("upgrade completed")
         self.peer_relation.data[self.charm.unit].update({"state": "completed"})

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -990,6 +990,7 @@ class DataUpgrade(Object, ABC):
             event.fail(message="Unknown error found.")
             return
 
+        # always 'safe' on k8s, default to 'auto' on vm
         resume_strategy = (
             "safe" if self.substrate == "k8s" else event.params.get("resume-strategy", "auto")
         )

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -284,7 +284,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 9
 
 PYDEPS = ["pydantic>=1.10,<2"]
 

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -801,10 +801,10 @@ class DataUpgrade(Object, ABC):
 
     @property
     def first_unit(self) -> bool:
-        """TODO.
+        """Flag to check if the current top-of-stack unit is the first to upgrade.
 
         Returns:
-            String of TODO
+            True if top-of-stack unit is the first to upgrade. Otherwise False
         """
         if not self.peer_relation or not self.upgrade_stack:
             return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ target-version="py310"
 src = ["src", "tests", "lib"]
 
 [tool.ruff.mccabe]
-max-complexity = 12
+max-complexity = 15
 
 [tool.pyright]
 include = ["src", "lib"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ target-version="py310"
 src = ["src", "tests", "lib"]
 
 [tool.ruff.mccabe]
-max-complexity = 15
+max-complexity = 13
 
 [tool.pyright]
 include = ["src", "lib"]


### PR DESCRIPTION
## TODO
- Test on live charm when K8s examples exist
- Add + update tests
- Add + update full usage docstring

## Changes Made
#### `refactor: remove upgrade-finished event + handler, use relation-changed`
- Moving the logic to relation-changed to be coordinated by the Juju leader
- NOTE - Does mean that charms need to recurse on leader. Possibly not as have added a call on `set_unit_completed`. Needs testing

#### `feat: add resume-strategy to pre-upgrade-check`
- `auto` - all units upgrade automatically
   - Default on VM
- `safe` - upgrade pauses on first unit
   - Default on K8s

#### `refactor: add unified _update_stack()`
- Leader-only
- On K8s, shifts partition
- Updates relation-data stack
- Called during `resume-upgrade` action, and if completed top of stack + first unit + 'safe'