### PR TITLE
clean exit when a unit not yet in the upgrade relation

### DIFF
--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -284,7 +284,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 10
+LIBPATCH = 11
 
 PYDEPS = ["pydantic>=1.10,<2"]
 

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -1127,7 +1127,14 @@ class DataUpgrade(Object, ABC):
         # pop mutates the `upgrade_stack` attr
         top_unit_id = self.upgrade_stack.pop()
         top_unit = self.charm.model.get_unit(f"{self.charm.app.name}/{top_unit_id}")
-        top_state = self.peer_relation.data[top_unit].get("state")
+        try:
+            top_state = self.peer_relation.data[top_unit].get("state")
+        except KeyError:
+            # a unit may not have joined the relation when  upgrading from
+            # an older version of the charm without upgrade support
+            # the hook will retrigger when it joins
+            logger.debug(f"{top_unit} not found in peer relation data, exiting...")
+            return
 
         # if top of stack is completed, leader pops it
         if self.charm.unit.is_leader() and top_state == "completed":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ target-version="py310"
 src = ["src", "tests", "lib"]
 
 [tool.ruff.mccabe]
-max-complexity = 12
+max-complexity = 13
 
 [tool.pyright]
 include = ["src", "lib"]


### PR DESCRIPTION
### Issue

**edge case**: When refreshing from a charm version without upgrade support, `on_upgrade_changed` hook error if the top_stack unit has not yet joined the relation.

**context**: mysql need to be able to support upgrade from the current stable version (if possible) to minimize noise from users. Check [PR301](https://github.com/canonical/mysql-operator/pull/301)


