### PR TITLE
[DPE-2342] Charm Relation (i.e. 'external') Secrets

### DIFF
--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -291,6 +291,7 @@ creating a new topic when other information other than a topic name is
 exchanged in the relation databag.
 """
 
+import copy
 import json
 import logging
 from abc import ABC, abstractmethod
@@ -299,7 +300,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Dict, List, Optional, Union
 
-from ops import Handle, JujuVersion, Secret
+from ops import Handle, JujuVersion, Secret, SecretInfo
 from ops.charm import (
     CharmBase,
     CharmEvents,
@@ -314,11 +315,11 @@ from ops.model import Application, ModelError, Relation, Unit
 LIBID = "6c3e6b6680d64e9c89e611d1a15f65be"
 
 # Increment this major API version when introducing breaking changes
-LIBAPI = 1
+LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 0
+LIBPATCH = 17
 
 PYDEPS = ["ops>=2.0.0"]
 
@@ -333,8 +334,19 @@ changed - keys that still exist but have new values
 deleted - key that were deleted"""
 
 
+# Local map to associate labels with secrets potentially as a group
+SECRET_LABEL_MAP = {
+    "username": "user",
+    "password": "user",
+    "tls": "tls",
+    "tls-ca": "tls",
+    "endpoints": "endpoints",
+    "uris": "uris",
+}
+
+
 class DataInterfacesError(Exception):
-    """Common ancestor for Secrets related exceptions."""
+    """Common ancestor for DataInterfaces related exceptions."""
 
 
 class SecretError(Exception):
@@ -343,6 +355,10 @@ class SecretError(Exception):
 
 class SecretAlreadyExistsError(SecretError):
     """A secret that was to be added already exists."""
+
+
+class SecretsUnavailableError(SecretError):
+    """Secrets aren't yet available for Juju version used."""
 
 
 def diff(event: RelationChangedEvent, bucket: Union[Unit, Application]) -> Diff:
@@ -379,6 +395,28 @@ def diff(event: RelationChangedEvent, bucket: Union[Unit, Application]) -> Diff:
     return Diff(added, changed, deleted)
 
 
+def leader_only(f):
+    """Decorator to ensure that only leader can perform given operation."""
+
+    def wrapper(self, *args, **kwargs):
+        if not self.local_unit.is_leader():
+            return
+        return f(self, *args, **kwargs)
+
+    return wrapper
+
+
+def juju_secrets_only(f):
+    """Decorator to ensure that certain operations would be only executed on Juju3."""
+
+    def wrapper(self, *args, **kwargs):
+        if not self.secrets_enabled:
+            raise SecretsUnavailableError("Secrets unavailable on current Juju version")
+        return f(self, *args, **kwargs)
+
+    return wrapper
+
+
 class Scope(Enum):
     """Peer relations scope."""
 
@@ -393,30 +431,6 @@ class SecretCache:
     """
 
     def __init__(self, charm: CharmBase, secret_uri: Optional[str] = None):
-        # Structure:
-        # NOTE: "objects" (i.e. dict-s) and scalar values are handled in a unified way
-        # precisely as done for the Secret objects themselves.
-        #
-        # self.secrets = {
-        #   "app": {
-        #       "opensearch:app:admin-password": {
-        #           "meta": <Secret instance>,
-        #           "content": {
-        #               "opensearch:app:admin-password": "bla"
-        #           }
-        #       }
-        #   },
-        #   "unit": {
-        #       "opensearch:unit:0:certificates": {
-        #           "meta": <Secret instance>,
-        #           "content": {
-        #               "ca-cert": "<certificate>",
-        #               "cert": "<certificate>",
-        #               "chain": "<certificate>"
-        #           }
-        #       }
-        #   }
-        # }
         self._secret_meta = None
         self._secret_content = {}
         self._secret_uri = secret_uri
@@ -425,14 +439,18 @@ class SecretCache:
     def add_secret(self, content: Dict[str, str], relation: Relation) -> Secret:
         """Create a new secret."""
         if self._secret_uri:
-            raise SecretAlreadyExistsError("Secret is already defined for")
+            raise SecretAlreadyExistsError(
+                "Secret is already defined with uri %s", self._secret_uri
+            )
+
         secret = self.charm.app.add_secret(content)
         secret.grant(relation)
         self._secret_uri = secret.id
-        self._secret = secret
-        return self._secret
+        self._secret_meta = secret
+        return self._secret_meta
 
-    def get_secret(self) -> Optional[Secret]:
+    @property
+    def meta(self) -> Optional[Secret]:
         """Getting cached secret meta-information."""
         if not self._secret_meta:
             if not self._secret_uri:
@@ -440,18 +458,23 @@ class SecretCache:
             self._secret_meta = self.charm.model.get_secret(id=self._secret_uri)
         return self._secret_meta
 
-    def get_content(self, scope: Scope, label: str) -> Dict[str, str]:
+    def get_content(self) -> Dict[str, str]:
         """Getting cached secret content."""
         if not self._secret_content:
-            if secret_meta := self.get_secret():
-                self._secret_content = secret_meta.get_content()
+            if self.meta:
+                self._secret_content = self.meta.get_content()
         return self._secret_content
 
-    def set_content(self, scope: Scope, label: str, content: Dict[str, str]) -> None:
+    def set_content(self, content: Dict[str, str]) -> None:
         """Setting cached secret content."""
-        if secret_meta := self.get_secret():
-            secret_meta.set_content(content)
+        if self.meta:
+            self.meta.set_content(content)
             self._secret_content = content
+
+    def get_info(self) -> Optional[SecretInfo]:
+        """Wrapper function to provide direct access to contained Secret's equal function."""
+        if self.meta:
+            return self.meta.get_info()
 
 
 # Base DataRelation
@@ -517,26 +540,19 @@ class DataRelation(Object, ABC):
 
         return relation
 
-    def get_relation_secret(
-        self, relation_id: int, relation_name: Optional[str] = None
-    ) -> Optional[Secret]:
+    @abstractmethod
+    def _get_relation_secret(
+        self, relation_id: int, label: str, relation_name: Optional[str] = None
+    ) -> Optional[SecretCache]:
         """Retrieve a Juju Secret that's been stored in the relation databag."""
-        if not relation_name:
-            relation_name = self.relation_name
+        raise NotImplementedError
 
-        if not self.secrets.get(relation_id) and self.secrets_enabled:
-            relation = self.charm.model.get_relation(relation_name, relation_id)
-            if not relation:
-                return
-            if secret_id := relation.data[self.local_app].get("secret"):
-                self.secrets[relation_id] = SecretCache(self.charm, secret_id).get_secret()
-        return self.secrets.get(relation_id)
-
+    @juju_secrets_only
     def get_relation_secret_data(
-        self, relation_id: int, relation_name: Optional[str] = None
+        self, relation_id: int, label: str, relation_name: Optional[str] = None
     ) -> Optional[Dict[str, str]]:
         """Retrieve contents of a Juju Secret that's been stored in the relation databag."""
-        secret = self.get_relation_secret(relation_id, relation_name)
+        secret = self._get_relation_secret(relation_id, label, relation_name)
         if secret:
             return secret.get_content()
 
@@ -560,6 +576,7 @@ class DataRelation(Object, ABC):
             )
         return data
 
+    @leader_only
     def _update_relation_data(self, relation_id: int, data: dict) -> None:
         """Updates a set of key-value pairs in the relation.
 
@@ -571,10 +588,17 @@ class DataRelation(Object, ABC):
             data: dict containing the key-value pairs
                 that should be updated in the relation.
         """
-        if self.local_unit.is_leader():
-            relation = self.charm.model.get_relation(self.relation_name, relation_id)
-            if relation:
-                relation.data[self.local_app].update(data)
+        relation = self.charm.model.get_relation(self.relation_name, relation_id)
+        if relation:
+            relation.data[self.local_app].update(data)
+
+    @staticmethod
+    def _create_label_sorted_content(keys: List[str]) -> Dict[str, List[str]]:
+        """Helper function to arrange secret labels under their group."""
+        label_sorted_content = {}
+        for key in keys:
+            label_sorted_content.setdefault(SECRET_LABEL_MAP[key], []).append(key)
+        return label_sorted_content
 
 
 # Base DataProvides and DataRequires
@@ -598,60 +622,96 @@ class DataProvides(DataRelation):
         """
         return diff(event, self.local_app)
 
-    def add_relation_secret(self, relation_id, content) -> Optional[Secret]:
+    @leader_only
+    @juju_secrets_only
+    def add_relation_secret(
+        self, relation_id: int, content: Dict[str, str], label: str
+    ) -> Optional[Secret]:
         """Add a new Juju Secret that will be registered in the relation databag."""
-        if not self.local_unit.is_leader():
-            return
-
         relation = self.get_relation(self.relation_name, relation_id)
 
-        if relation.data[self.local_app].get("secret"):
+        if relation.data[self.local_app].get(f"secret-{label}"):
             logging.error("Secret for relation %s already exists, not adding again", relation_id)
             return
 
-        secret = SecretCache(self.charm).add_secret(content, relation)
+        secret = SecretCache(self.charm)
+        secret.add_secret(content, relation)
 
         # According to lint we may not have a Secret ID
-        if secret.id:
-            relation.data[self.local_app]["secret"] = secret.id
-            self.secrets[relation_id] = secret
-            return secret
+        if secret.meta and secret.meta.id and (secret_info := secret.get_info()):
+            relation.data[self.local_app][f"secret-{label}"] = secret.meta.id
+            relation.data[self.local_app][f"secret-{label}-revision"] = str(secret_info.revision)
+            self.secrets.setdefault(relation_id, {})[label] = secret
 
-    def update_relation_secret(self, relation_id, content):
-        """Update the contenst of an existing Juju Secret, stored in the relation databag."""
-        if not self.local_unit.is_leader():
-            return
-
-        secret = self.get_relation_secret(relation_id)
+    @leader_only
+    @juju_secrets_only
+    def update_relation_secret(self, relation_id: int, content: Dict[str, str], label: str):
+        """Update the contents of an existing Juju Secret, referred in the relation databag."""
+        secret = self._get_relation_secret(relation_id, label)
 
         if not secret:
             logging.error("Can't update secret for relation %s", relation_id)
             return
 
-        full_content = secret.get_content()
+        old_content = secret.get_content()
+        full_content = copy.deepcopy(old_content)
         full_content.update(content)
         secret.set_content(full_content)
 
+        # We only have a new revision, if the secret contents changed
+        if old_content != full_content and secret.meta and (secret_info := secret.get_info()):
+            relation = self.get_relation(self.relation_name, relation_id)
+
+            # Horrible hack to work around the fact that we can't query a secret's new revision after update
+            relation.data[self.local_app][f"secret-{label}-revision"] = str(
+                secret_info.revision + 1
+            )
+
+    @juju_secrets_only
+    def _get_relation_secret(
+        self, relation_id: int, label: str, relation_name: Optional[str] = None
+    ) -> Optional[SecretCache]:
+        """Retrieve a Juju Secret that's been stored in the relation databag."""
+        if not relation_name:
+            relation_name = self.relation_name
+
+        if not self.secrets.get(relation_id, {}).get(label):
+            relation = self.charm.model.get_relation(relation_name, relation_id)
+            if not relation:
+                return
+            if secret_id := relation.data[self.local_app].get(f"secret-{label}"):
+                self.secrets.setdefault(relation_id, {})[label] = SecretCache(
+                    self.charm, secret_id
+                )
+        return self.secrets.get(relation_id, {}).get(label)
+
+    @leader_only
     def set_relation_fields(self, relation_id: int, fields: Dict[str, str]) -> None:
-        """Get the value of a field not caring whether it's a secret or not."""
+        """Set values for fields not caring whether it's a secret or not."""
         relation = self.get_relation(self.relation_name, relation_id)
         relation_secret_fields = relation.data.get(
             relation.app, {}  # pyright: ignore [reportGeneralTypeIssues]
         ).get("secret_fields")
 
         normal_fields = list(fields)
-        if relation_secret_fields:
+        if relation_secret_fields and self.secrets_enabled:
             relation_secret_fields = relation_secret_fields.split(" ")
             normal_fields = set(fields.keys()) - set(relation_secret_fields)
             secret_fields = set(fields.keys()) - set(normal_fields)
 
-            if secret_fields and self.secrets_enabled:
-                secret_content = {k: v for k, v in fields.items() if k in secret_fields}
+            label_sorted_content = self._create_label_sorted_content(list(fields.keys()))
 
-                if self.get_relation_secret(relation_id):
-                    self.update_relation_secret(relation_id, secret_content)
+            for label in label_sorted_content:
+                secret_content = {
+                    k: v
+                    for k, v in fields.items()
+                    if k in secret_fields and SECRET_LABEL_MAP[k] == label
+                }
+
+                if self._get_relation_secret(relation_id, label):
+                    self.update_relation_secret(relation_id, secret_content, label)
                 else:
-                    self.add_relation_secret(relation_id, secret_content)
+                    self.add_relation_secret(relation_id, secret_content, label)
 
         normal_content = {k: v for k, v in fields.items() if k in normal_fields}
         relation.data[self.local_app].update(  # pyright: ignore [reportGeneralTypeIssues]
@@ -693,7 +753,7 @@ class DataProvides(DataRelation):
 class DataRequires(DataRelation):
     """Requires-side of the relation."""
 
-    SECRET_FIELDS = ["username", "password", "tls", "tls_ca"]
+    SECRET_FIELDS = ["username", "password", "tls", "tls-ca", "endpoints", "uris"]
 
     def __init__(
         self,
@@ -708,10 +768,17 @@ class DataRequires(DataRelation):
             self.charm.on[relation_name].relation_created, self._on_relation_created_event
         )
 
+    @property
+    def secret_fields(self) -> Optional[List[str]]:
+        """Local access to secrets field, in case they are being used."""
+        if self.secrets_enabled:
+            return self.SECRET_FIELDS
+
     def _on_relation_created_event(self, event: RelationCreatedEvent) -> None:
         """Event emitted when the relation is created."""
         if not self.local_unit.is_leader():
             return
+
         if self.secrets_enabled:
             event.relation.data[self.charm.app]["secret_fields"] = " ".join(self.SECRET_FIELDS)
 
@@ -727,6 +794,24 @@ class DataRequires(DataRelation):
         """
         return diff(event, self.local_unit)
 
+    @juju_secrets_only
+    def _get_relation_secret(
+        self, relation_id: int, label: str, relation_name: Optional[str] = None
+    ) -> Optional[SecretCache]:
+        """Retrieve a Juju Secret that's been stored in the relation databag."""
+        if not relation_name:
+            relation_name = self.relation_name
+
+        if not self.secrets.get(relation_id, {}).get(label):
+            relation = self.charm.model.get_relation(relation_name, relation_id)
+            if not relation or not relation.app:
+                return
+            if secret_id := relation.data[relation.app].get(f"secret-{label}"):
+                self.secrets.setdefault(relation_id, {})[label] = SecretCache(
+                    self.charm, secret_id
+                )
+        return self.secrets.get(relation_id, {}).get(label)
+
     def get_relation_fields(
         self, relation_id: int, fields: List[str], relation_name: Optional[str] = None
     ) -> Dict[str, str]:
@@ -736,20 +821,18 @@ class DataRequires(DataRelation):
 
         result = {}
         relation = self.get_relation(relation_name, relation_id)
-        relation_secret_fields = relation.data.get(
-            relation.app, {}  # pyright: ignore [reportGeneralTypeIssues]
-        ).get("secret_fields")
 
         normal_fields = fields
-        if relation_secret_fields:
-            relation_secret_fields = relation_secret_fields.split(" ")
-            normal_fields = set(fields) - set(relation_secret_fields)
+        if self.secret_fields and self.secrets_enabled:
+            normal_fields = set(fields) - set(self.secret_fields)
             secret_fields = set(fields) - set(normal_fields)
 
-            if secret_fields and self.secrets_enabled:
-                if secret := self.get_relation_secret(relation_id):
-                    if secret_data := secret.get_content():
-                        result.update({k: v for k, v in secret_data.items() if k in secret_fields})
+            label_sorted_content = self._create_label_sorted_content(fields)
+            for label in label_sorted_content:
+                if (secret := self._get_relation_secret(relation_id, label)) and (
+                    secret_data := secret.get_content()
+                ):
+                    result.update({k: v for k, v in secret_data.items() if k in secret_fields})
 
         result.update(
             {
@@ -758,6 +841,12 @@ class DataRequires(DataRelation):
             }
         )
         return result
+
+    def get_relation_field(
+        self, relation_id: int, field: str, relation_name: Optional[str] = None
+    ) -> Optional[str]:
+        """Get a single field from the relation data."""
+        return self.get_relation_fields(relation_id, [field], relation_name).get(field)
 
     def _is_resource_created_for_relation(self, relation: Relation) -> bool:
         if not relation.app:
@@ -989,10 +1078,9 @@ class DatabaseProvides(DataProvides):
 
     def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
         """Event emitted when the relation has changed."""
-        # Only the leader should handle this event.
+        # Leader only
         if not self.local_unit.is_leader():
             return
-
         # Check which data has changed to emit customs events.
         diff = self._diff(event)
 
@@ -1029,7 +1117,7 @@ class DatabaseProvides(DataProvides):
             relation_id: the identifier for a particular relation.
             connection_strings: database hosts and ports comma separated list.
         """
-        self._update_relation_data(relation_id, {"endpoints": connection_strings})
+        self.set_relation_fields(relation_id, {"endpoints": connection_strings})
 
     def set_read_only_endpoints(self, relation_id: int, connection_strings: str) -> None:
         """Set database replicas connection strings.
@@ -1063,7 +1151,7 @@ class DatabaseProvides(DataProvides):
             relation_id: the identifier for a particular relation.
             uris: connection URIs.
         """
-        self._update_relation_data(relation_id, {"uris": uris})
+        self.set_relation_fields(relation_id, {"uris": uris})
 
     def set_version(self, relation_id: int, version: str) -> None:
         """Set the database version in the application relation databag.
@@ -1190,8 +1278,8 @@ class DatabaseRequires(DataRequires):
         if len(self.relations) == 0:
             return False
 
-        relation_data = self.fetch_relation_data()[self.relations[relation_index].id]
-        host = relation_data.get("endpoints")
+        relation_id = self.relations[relation_index].id
+        host = self.get_relation_field(relation_id, "endpoints")
 
         # Return False if there is no endpoint available.
         if host is None:
@@ -1199,13 +1287,9 @@ class DatabaseRequires(DataRequires):
 
         host = host.split(":")[0]
 
-        if relation_data.get("secret"):
-            content = self.get_relation_secret_data(relation_index)
-            user = content.get("username")
-            password = content.get("password")
-        else:
-            user = relation_data.get("username")
-            password = relation_data.get("password")
+        content = self.get_relation_fields(relation_id, ["username", "password"])
+        user = content.get("username")
+        password = content.get("password")
 
         connection_string = (
             f"host='{host}' dbname='{self.database}' user='{user}' password='{password}'"
@@ -1251,11 +1335,7 @@ class DatabaseRequires(DataRequires):
         # Check if the database is created
         # (the database charm shared the credentials).
 
-        new_secret_content = None
-        if self.secrets_enabled and "secret" in diff.added:
-            new_secret_content = self.get_relation_fields(event.relation.id, ["username", "password"])
-
-        if ("username" in diff.added and "password" in diff.added) or new_secret_content:
+        if ("username" in diff.added and "password" in diff.added) or "secret-user" in diff.added:
             # Emit the default event (the one without an alias).
             logger.info("database created at %s", datetime.now())
             getattr(self.on, "database_created").emit(
@@ -1271,7 +1351,12 @@ class DatabaseRequires(DataRequires):
 
         # Emit an endpoints changed event if the database
         # added or changed this info in the relation databag.
-        if "endpoints" in diff.added or "endpoints" in diff.changed:
+        if (
+            "endpoints" in diff.added
+            or "endpoints" in diff.changed
+            or "secret-endpoints" in diff.added
+            or "secret-endpoints-revision" in diff.changed
+        ):
             # Emit the default event (the one without an alias).
             logger.info("endpoints changed on %s", datetime.now())
             getattr(self.on, "endpoints_changed").emit(
@@ -1401,7 +1486,7 @@ class KafkaProvides(DataProvides):
 
     def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
         """Event emitted when the relation has changed."""
-        # Only the leader should handle this event.
+        # Leader only
         if not self.local_unit.is_leader():
             return
 
@@ -1431,7 +1516,7 @@ class KafkaProvides(DataProvides):
             relation_id: the identifier for a particular relation.
             bootstrap_server: the bootstrap server address.
         """
-        self._update_relation_data(relation_id, {"endpoints": bootstrap_server})
+        self.set_relation_fields(relation_id, {"endpoints": bootstrap_server})
 
     def set_consumer_group_prefix(self, relation_id: int, consumer_group_prefix: str) -> None:
         """Set the consumer group prefix in the application relation databag.
@@ -1504,11 +1589,7 @@ class KafkaRequires(DataRequires):
         # Check if the topic is created
         # (the Kafka charm shared the credentials).
 
-        new_secret_content = None
-        if self.secrets_enabled and "secret" in diff.added:
-            new_secret_content = self.get_relation_fields(event.relation.id, ["username", "password"])
-
-        if ("username" in diff.added and "password" in diff.added) or new_secret_content:
+        if ("username" in diff.added and "password" in diff.added) or "secret-user" in diff.added:
             # Emit the default event (the one without an alias).
             logger.info("topic created at %s", datetime.now())
             getattr(self.on, "topic_created").emit(event.relation, app=event.app, unit=event.unit)
@@ -1519,7 +1600,12 @@ class KafkaRequires(DataRequires):
 
         # Emit an endpoints (bootstrap-server) changed event if the Kafka endpoints
         # added or changed this info in the relation databag.
-        if "endpoints" in diff.added or "endpoints" in diff.changed:
+        if (
+            "endpoints" in diff.added
+            or "endpoints" in diff.changed
+            or "secret-endpoints" in diff.added
+            or "secret-endpoints-revision" in diff.changed
+        ):
             # Emit the default event (the one without an alias).
             logger.info("endpoints changed on %s", datetime.now())
             getattr(self.on, "bootstrap_server_changed").emit(
@@ -1588,10 +1674,9 @@ class OpenSearchProvides(DataProvides):
 
     def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
         """Event emitted when the relation has changed."""
-        # Only the leader should handle this event.
+        # Leader only
         if not self.local_unit.is_leader():
             return
-
         # Check which data has changed to emit customs events.
         diff = self._diff(event)
 
@@ -1620,7 +1705,7 @@ class OpenSearchProvides(DataProvides):
             relation_id: the identifier for a particular relation.
             endpoints: the endpoint addresses for opensearch nodes.
         """
-        self._update_relation_data(relation_id, {"endpoints": endpoints})
+        self.set_relation_fields(relation_id, {"endpoints": endpoints})
 
     def set_version(self, relation_id: int, version: str) -> None:
         """Set the opensearch version in the application relation databag.
@@ -1666,20 +1751,16 @@ class OpenSearchRequires(DataRequires):
         diff = self._diff(event)
 
         # Check if authentication has updated, emit event if so
-        updates = {"username", "password", "tls", "tls-ca", "secret"}
+        updates = {"username", "password", "tls", "tls-ca", "secret-user", "secret-tls"}
         if len(set(diff._asdict().keys()) - updates) < len(diff):
             logger.info("authentication updated at: %s", datetime.now())
             getattr(self.on, "authentication_updated").emit(
                 event.relation, app=event.app, unit=event.unit
             )
 
-        new_secret_content = None
-        if self.secrets_enabled and "secret" in diff.added:
-            new_secret_content = self.get_relation_fields(event.relation.id, ["username", "password"])
-
         # Check if the index is created
         # (the OpenSearch charm shares the credentials).
-        if ("username" in diff.added and "password" in diff.added) or new_secret_content:
+        if ("username" in diff.added and "password" in diff.added) or "secret-user" in diff.added:
             # Emit the default event (the one without an alias).
             logger.info("index created at: %s", datetime.now())
             getattr(self.on, "index_created").emit(event.relation, app=event.app, unit=event.unit)
@@ -1690,7 +1771,12 @@ class OpenSearchRequires(DataRequires):
 
         # Emit a endpoints changed event if the OpenSearch application added or changed this info
         # in the relation databag.
-        if "endpoints" in diff.added or "endpoints" in diff.changed:
+        if (
+            "endpoints" in diff.added
+            or "endpoints" in diff.changed
+            or "secret-endpoints" in diff.added
+            or "secret-endpoints-revision" in diff.changed
+        ):
             # Emit the default event (the one without an alias).
             logger.info("endpoints changed on %s", datetime.now())
             getattr(self.on, "endpoints_changed").emit(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,51 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+import os
+from importlib.metadata import version
+from unittest.mock import PropertyMock
+
+import pytest
+from ops import JujuVersion
+from pytest_mock import MockerFixture
+
+
+@pytest.fixture(autouse=True)
+def juju_has_secrets(mocker: MockerFixture):
+    """This fixture will force the usage of secrets whenever run on Juju 3.x.
+
+    NOTE: This is needed, as normally JujuVersion is set to 0.0.0 in tests
+    (i.e. not the real juju version)
+    """
+    if juju_version := os.environ.get("LIBJUJU_VERSION_SPECIFIER"):
+        juju_version.replace("==", "")
+        juju_version = juju_version[2:].split(".")[0]
+    else:
+        juju_version = version("juju")
+
+    if juju_version < "3":
+        mocker.patch.object(
+            JujuVersion, "has_secrets", new_callable=PropertyMock
+        ).return_value = False
+        return False
+    else:
+        mocker.patch.object(
+            JujuVersion, "has_secrets", new_callable=PropertyMock
+        ).return_value = True
+        return True
+
+
+@pytest.fixture
+def only_with_juju_secrets(juju_has_secrets):
+    """Pretty way to skip Juju 3 tests."""
+    if not juju_has_secrets:
+        pytest.skip("Secrets test only applies on Juju 3.x")
+
+
+@pytest.fixture
+def only_without_juju_secrets(juju_has_secrets):
+    """Pretty way to skip Juju 2-specific tests.
+
+    Typically: to save CI time, when the same check were executed in a Juju 3-specific way already
+    """
+    if juju_has_secrets:
+        pytest.skip("Skipping legacy secrets tests")

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -43,11 +43,23 @@ async def build_connection_string(
 
     if JujuVersion.from_environ().has_secrets:
         secret_uri = await get_application_relation_data(
-            ops_test, application_name, relation_name, "secret", relation_id, relation_alias
+            ops_test, application_name, relation_name, "secret-user", relation_id, relation_alias
         )
         secret_data = await get_juju_secret(ops_test, secret_uri)
         username = secret_data["username"]
         password = secret_data["password"]
+
+        secret_uri = await get_application_relation_data(
+            ops_test,
+            application_name,
+            relation_name,
+            "secret-endpoints",
+            relation_id,
+            relation_alias,
+        )
+        secret_data = await get_juju_secret(ops_test, secret_uri)
+        endpoints = secret_data["endpoints"]
+
     else:
         username = await get_application_relation_data(
             ops_test, application_name, relation_name, "username", relation_id, relation_alias
@@ -55,9 +67,9 @@ async def build_connection_string(
         password = await get_application_relation_data(
             ops_test, application_name, relation_name, "password", relation_id, relation_alias
         )
-    endpoints = await get_application_relation_data(
-        ops_test, application_name, relation_name, "endpoints", relation_id, relation_alias
-    )
+        endpoints = await get_application_relation_data(
+            ops_test, application_name, relation_name, "endpoints", relation_id, relation_alias
+        )
     host = endpoints.split(",")[0].split(":")[0]
 
     # Build the complete connection string to connect to the database.

--- a/tests/integration/kafka-charm/src/charm.py
+++ b/tests/integration/kafka-charm/src/charm.py
@@ -110,11 +110,6 @@ class KafkaCharm(CharmBase):
         logger.info("On sync password")
 
         password = event.params.get("password")
-        if not password:
-            secret_uri = event.params.get("secret")
-            secret_contents = self.charm.model.get_secret(id=secret_uri).get_content()
-            password = secret_contents.get("password")
-
         self.set_secret("app", "password", password)
         logger.info(f"New password: {password}")
         # set parameters in the secrets
@@ -131,11 +126,6 @@ class KafkaCharm(CharmBase):
     def _on_sync_username(self, event: ActionEvent):
         """Set the username in the data relation databag."""
         username = event.params["username"]
-        if not username:
-            secret_uri = event.params.get("secret")
-            secret_contents = self.charm.model.get_secret(id=secret_uri).get_content()
-            username = secret_contents.get("username")
-
         self.set_secret("app", "username", username)
 
         # set parameters in the secrets

--- a/tests/integration/kafka-charm/src/charm.py
+++ b/tests/integration/kafka-charm/src/charm.py
@@ -108,7 +108,13 @@ class KafkaCharm(CharmBase):
     def _on_sync_password(self, event: ActionEvent):
         """Set the password in the data relation databag."""
         logger.info("On sync password")
-        password = event.params["password"]
+
+        password = event.params.get("password")
+        if not password:
+            secret_uri = event.params.get("secret")
+            secret_contents = self.charm.model.get_secret(id=secret_uri).get_content()
+            password = secret_contents.get("password")
+
         self.set_secret("app", "password", password)
         logger.info(f"New password: {password}")
         # set parameters in the secrets
@@ -125,7 +131,13 @@ class KafkaCharm(CharmBase):
     def _on_sync_username(self, event: ActionEvent):
         """Set the username in the data relation databag."""
         username = event.params["username"]
+        if not username:
+            secret_uri = event.params.get("secret")
+            secret_contents = self.charm.model.get_secret(id=secret_uri).get_content()
+            username = secret_contents.get("username")
+
         self.set_secret("app", "username", username)
+
         # set parameters in the secrets
         # update relation data if the relation is present
         if len(self.kafka_provider.relations) > 0:

--- a/tests/integration/test_kafka_charm.py
+++ b/tests/integration/test_kafka_charm.py
@@ -94,16 +94,19 @@ async def test_kafka_relation_with_charm_libraries_secrets(ops_test: OpsTest):
         assert "granted" in unit.workload_status_message
 
     secret_uri = await get_application_relation_data(
-        ops_test, APPLICATION_APP_NAME, RELATION_NAME, "secret"
+        ops_test, APPLICATION_APP_NAME, RELATION_NAME, "secret-user"
     )
 
     secret_content = await get_juju_secret(ops_test, secret_uri)
     username = secret_content["username"]
     password = secret_content["password"]
 
-    boostrap_server = await get_application_relation_data(
-        ops_test, APPLICATION_APP_NAME, RELATION_NAME, "endpoints"
+    secret_uri = await get_application_relation_data(
+        ops_test, APPLICATION_APP_NAME, RELATION_NAME, "secret-endpoints"
     )
+    secret_content = await get_juju_secret(ops_test, secret_uri)
+    bootstrap_server = secret_content["endpoints"]
+
     consumer_group_prefix = await get_application_relation_data(
         ops_test, APPLICATION_APP_NAME, RELATION_NAME, "consumer-group-prefix"
     )
@@ -114,11 +117,12 @@ async def test_kafka_relation_with_charm_libraries_secrets(ops_test: OpsTest):
 
     assert username == "admin"
     assert password == "password"
-    assert boostrap_server == "host1:port,host2:port"
+    assert bootstrap_server == "host1:port,host2:port"
     assert consumer_group_prefix == "test-prefix"
     assert topic == "test-topic"
 
 
+@pytest.mark.usefixtures("only_without_juju_secrets")
 async def test_kafka_bootstrap_server_changed(ops_test: OpsTest):
     """Test that the bootstrap server changed event is correctly triggered."""
     app_unit = ops_test.model.applications[APPLICATION_APP_NAME].units[0]
@@ -154,6 +158,61 @@ async def test_kafka_bootstrap_server_changed(ops_test: OpsTest):
         ops_test, APPLICATION_APP_NAME, RELATION_NAME, "endpoints"
     )
     assert bootstrap_server == "host1:port,host2:port,host3:port"
+    # check the bootstrap_server_changed event is NOT triggered
+    for unit in ops_test.model.applications[APPLICATION_APP_NAME].units:
+        assert unit.workload_status_message == ""
+
+
+@pytest.mark.usefixtures("only_with_juju_secrets")
+async def test_kafka_bootstrap_server_changed_secrets(ops_test: OpsTest):
+    """Test that the bootstrap server changed event is correctly triggered."""
+    app_unit = ops_test.model.applications[APPLICATION_APP_NAME].units[0]
+    kafka_unit = ops_test.model.applications[KAFKA_APP_NAME].units[0]
+    # set new bootstrap
+    parameters = {"bootstrap-server": "host1:port,host2:port,host3:port"}
+    action = await kafka_unit.run_action(action_name="sync-bootstrap-server", **parameters)
+    result = await action.wait()
+    await ops_test.model.wait_for_idle(apps=APP_NAMES, status="active")
+    assert result.results["bootstrap-server"] == "host1:port,host2:port,host3:port"
+
+    # check that the new bootstrap-server is set as a secret
+    secret_uri = await get_application_relation_data(
+        ops_test, APPLICATION_APP_NAME, RELATION_NAME, "secret-endpoints"
+    )
+    secret_content = await get_juju_secret(ops_test, secret_uri)
+    bootstrap_server = secret_content["endpoints"]
+    assert bootstrap_server == "host1:port,host2:port,host3:port"
+
+    # check that the bootstrap_server_changed event is triggered
+    for unit in ops_test.model.applications[APPLICATION_APP_NAME].units:
+        assert unit.workload_status_message == "kafka_bootstrap_server_changed"
+
+    # reset unit message
+    action = await app_unit.run_action(action_name="reset-unit-status")
+    result = await action.wait()
+    await ops_test.model.wait_for_idle(apps=APP_NAMES, status="active")
+
+    # check if the message is empty
+    for unit in ops_test.model.applications[APPLICATION_APP_NAME].units:
+        assert unit.workload_status_message == ""
+
+    # configure the same bootstrap-server
+    action = await kafka_unit.run_action(action_name="sync-bootstrap-server", **parameters)
+    result = await action.wait()
+    await ops_test.model.wait_for_idle(apps=APP_NAMES, status="active")
+    assert result.results["bootstrap-server"] == "host1:port,host2:port,host3:port"
+    bootstrap_server = await get_application_relation_data(
+        ops_test, APPLICATION_APP_NAME, RELATION_NAME, "endpoints"
+    )
+
+    # check that the new bootstrap-server secret
+    secret_uri = await get_application_relation_data(
+        ops_test, APPLICATION_APP_NAME, RELATION_NAME, "secret-endpoints"
+    )
+    secret_content = await get_juju_secret(ops_test, secret_uri)
+    bootstrap_server = secret_content["endpoints"]
+    assert bootstrap_server == "host1:port,host2:port,host3:port"
+
     # check the bootstrap_server_changed event is NOT triggered
     for unit in ops_test.model.applications[APPLICATION_APP_NAME].units:
         assert unit.workload_status_message == ""

--- a/tests/integration/test_kafka_charm.py
+++ b/tests/integration/test_kafka_charm.py
@@ -7,7 +7,7 @@ import logging
 import pytest
 from pytest_operator.plugin import OpsTest
 
-from .helpers import get_application_relation_data
+from .helpers import get_application_relation_data, get_juju_secret
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +39,7 @@ async def test_deploy_charms(ops_test: OpsTest, application_charm, kafka_charm):
 
 
 @pytest.mark.abort_on_fail
+@pytest.mark.usefixtures("only_without_juju_secrets")
 async def test_kafka_relation_with_charm_libraries(ops_test: OpsTest):
     """Test basic functionality of kafka relation interface."""
     # Relate the charms and wait for them exchanging some connection data.
@@ -58,6 +59,47 @@ async def test_kafka_relation_with_charm_libraries(ops_test: OpsTest):
     password = await get_application_relation_data(
         ops_test, APPLICATION_APP_NAME, RELATION_NAME, "password"
     )
+
+    boostrap_server = await get_application_relation_data(
+        ops_test, APPLICATION_APP_NAME, RELATION_NAME, "endpoints"
+    )
+    consumer_group_prefix = await get_application_relation_data(
+        ops_test, APPLICATION_APP_NAME, RELATION_NAME, "consumer-group-prefix"
+    )
+
+    topic = await get_application_relation_data(
+        ops_test, APPLICATION_APP_NAME, RELATION_NAME, "topic"
+    )
+
+    assert username == "admin"
+    assert password == "password"
+    assert boostrap_server == "host1:port,host2:port"
+    assert consumer_group_prefix == "test-prefix"
+    assert topic == "test-topic"
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.usefixtures("only_with_juju_secrets")
+async def test_kafka_relation_with_charm_libraries_secrets(ops_test: OpsTest):
+    """Test basic functionality of kafka relation interface."""
+    # Relate the charms and wait for them exchanging some connection data.
+    await ops_test.model.add_relation(KAFKA_APP_NAME, APPLICATION_APP_NAME)
+    await ops_test.model.wait_for_idle(apps=APP_NAMES, status="active")
+
+    # check unit messagge to check if the topic_created_event is triggered
+    for unit in ops_test.model.applications[APPLICATION_APP_NAME].units:
+        assert unit.workload_status_message == "kafka_topic_created"
+    # check if the topic was granted
+    for unit in ops_test.model.applications[KAFKA_APP_NAME].units:
+        assert "granted" in unit.workload_status_message
+
+    secret_uri = await get_application_relation_data(
+        ops_test, APPLICATION_APP_NAME, RELATION_NAME, "secret"
+    )
+
+    secret_content = await get_juju_secret(ops_test, secret_uri)
+    username = secret_content["username"]
+    password = secret_content["password"]
 
     boostrap_server = await get_application_relation_data(
         ops_test, APPLICATION_APP_NAME, RELATION_NAME, "endpoints"

--- a/tests/integration/test_opensearch_charm.py
+++ b/tests/integration/test_opensearch_charm.py
@@ -90,16 +90,19 @@ async def test_opensearch_relation_with_charm_libraries_secrets(ops_test: OpsTes
         assert "granted" in unit.workload_status_message
 
     secret_uri = await get_application_relation_data(
-        ops_test, APPLICATION_APP_NAME, RELATION_NAME, "secret"
+        ops_test, APPLICATION_APP_NAME, RELATION_NAME, "secret-user"
     )
 
     secret_content = await get_juju_secret(ops_test, secret_uri)
     username = secret_content["username"]
     password = secret_content["password"]
 
-    endpoints = await get_application_relation_data(
-        ops_test, APPLICATION_APP_NAME, RELATION_NAME, "endpoints"
+    secret_uri = await get_application_relation_data(
+        ops_test, APPLICATION_APP_NAME, RELATION_NAME, "secret-endpoints"
     )
+    secret_content = await get_juju_secret(ops_test, secret_uri)
+    endpoints = secret_content["endpoints"]
+
     index = await get_application_relation_data(
         ops_test, APPLICATION_APP_NAME, RELATION_NAME, "index"
     )

--- a/tests/integration/test_opensearch_charm.py
+++ b/tests/integration/test_opensearch_charm.py
@@ -7,7 +7,7 @@ import logging
 import pytest
 from pytest_operator.plugin import OpsTest
 
-from .helpers import get_application_relation_data
+from .helpers import get_application_relation_data, get_juju_secret
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +41,7 @@ async def test_deploy_charms(ops_test: OpsTest, application_charm, opensearch_ch
 
 
 @pytest.mark.abort_on_fail
+@pytest.mark.usefixtures("only_without_juju_secrets")
 async def test_opensearch_relation_with_charm_libraries(ops_test: OpsTest):
     """Test basic functionality of opensearch relation interface."""
     # Relate the charms and wait for them exchanging some connection data.
@@ -60,6 +61,42 @@ async def test_opensearch_relation_with_charm_libraries(ops_test: OpsTest):
     password = await get_application_relation_data(
         ops_test, APPLICATION_APP_NAME, RELATION_NAME, "password"
     )
+    endpoints = await get_application_relation_data(
+        ops_test, APPLICATION_APP_NAME, RELATION_NAME, "endpoints"
+    )
+    index = await get_application_relation_data(
+        ops_test, APPLICATION_APP_NAME, RELATION_NAME, "index"
+    )
+
+    assert username == "admin"
+    assert password == "password"
+    assert endpoints == "host1:port,host2:port"
+    assert index == "test-index"
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.usefixtures("only_with_juju_secrets")
+async def test_opensearch_relation_with_charm_libraries_secrets(ops_test: OpsTest):
+    """Test basic functionality of opensearch relation interface."""
+    # Relate the charms and wait for them exchanging some connection data.
+    await ops_test.model.add_relation(OPENSEARCH_APP_NAME, APPLICATION_APP_NAME)
+    await ops_test.model.wait_for_idle(apps=APP_NAMES, status="active")
+
+    # check unit messagge to check if the index_created_event is triggered
+    for unit in ops_test.model.applications[APPLICATION_APP_NAME].units:
+        assert unit.workload_status_message == "opensearch_index_created"
+    # check if index access is granted
+    for unit in ops_test.model.applications[OPENSEARCH_APP_NAME].units:
+        assert "granted" in unit.workload_status_message
+
+    secret_uri = await get_application_relation_data(
+        ops_test, APPLICATION_APP_NAME, RELATION_NAME, "secret"
+    )
+
+    secret_content = await get_juju_secret(ops_test, secret_uri)
+    username = secret_content["username"]
+    password = secret_content["password"]
+
     endpoints = await get_application_relation_data(
         ops_test, APPLICATION_APP_NAME, RELATION_NAME, "endpoints"
     )

--- a/tox.ini
+++ b/tox.ini
@@ -81,6 +81,7 @@ deps =
     pytest
     juju{env:LIBJUJU_VERSION_SPECIFIER:==2.9.42.4}
     pytest-operator
+    pytest-mock
     -r {tox_root}/requirements.txt
 commands =
     pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/test_charm.py
@@ -92,6 +93,7 @@ deps =
     pytest
     juju{env:LIBJUJU_VERSION_SPECIFIER:==2.9.42.4}
     pytest-operator
+    pytest-mock
     -r {tox_root}/requirements.txt
 commands =
     pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/test_kafka_charm.py
@@ -103,6 +105,7 @@ deps =
     pytest
     juju{env:LIBJUJU_VERSION_SPECIFIER:==2.9.42.4}
     pytest-operator
+    pytest-mock
     -r {tox_root}/requirements.txt
 commands =
     pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/test_s3_charm.py
@@ -114,6 +117,7 @@ deps =
     pytest
     juju{env:LIBJUJU_VERSION_SPECIFIER:==2.9.42.4}
     pytest-operator
+    pytest-mock
     -r {tox_root}/requirements.txt
 commands =
     pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/test_opensearch_charm.py

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ pass_env =
     PYTHONPATH
     CHARM_BUILD_DIR
     MODEL_SETTINGS
+    LIBJUJU_VERSION_SPECIFIER
 
 [testenv:format]
 description = Apply coding style standards to code
@@ -65,7 +66,6 @@ deps =
     parameterized
     psycopg[binary]
     pytest
-    juju{env:LIBJUJU_VERSION_SPECIFIER:==2.9.42.4}
     pytest-mock
     coverage[toml]
     -r {tox_root}/requirements.txt


### PR DESCRIPTION
## Disclaimer


Here we introduce Relations Secrets on top of the existing `data_interfaces` logic.

New interfaces:
   - `get_relation_secret_data()` (`Provides`, `Requires`)
   - `set_relation_secret_fields()` (`Provides`)
   - `get_relation_secret_fields()`, `get_relation_secret_fields()` (`Requires`)

POC demo of usage demonstrated on Opensearch: https://github.com/canonical/opensearch-operator/pull/116
