### PR TITLE
[DPE-2746] Set relation alias also on application data level

### DIFF
--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -1674,6 +1674,11 @@ class DatabaseRequires(DataRequires):
         if relation:
             relation.data[self.local_unit].update({"alias": available_aliases[0]})
 
+        # We need to set relation alias also on the application level so,
+        # it will be accessible in show-unit juju command, executed for a consumer application unit
+        self.update_relation_data(relation_id, {"alias": available_aliases[0]})
+
+
     def _emit_aliased_event(self, event: RelationChangedEvent, event_name: str) -> None:
         """Emit an aliased event to a particular relation if it has an alias.
 

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -1678,7 +1678,6 @@ class DatabaseRequires(DataRequires):
         # it will be accessible in show-unit juju command, executed for a consumer application unit
         self.update_relation_data(relation_id, {"alias": available_aliases[0]})
 
-
     def _emit_aliased_event(self, event: RelationChangedEvent, event_name: str) -> None:
         """Emit an aliased event to a particular relation if it has an alias.
 

--- a/tests/unit/test_data_interfaces.py
+++ b/tests/unit/test_data_interfaces.py
@@ -1254,6 +1254,7 @@ class TestDatabaseRequires(DataRequirerBaseTests, unittest.TestCase):
         data = self.harness.charm.requirer.fetch_my_relation_data()
         assert data == {
             self.rel_id: {
+                "alias": "cluster1",
                 "somedata": "somevalue",
                 "database": "data_platform",
                 "extra-user-roles": "CREATEDB,CREATEROLE",

--- a/tests/unit/test_data_interfaces.py
+++ b/tests/unit/test_data_interfaces.py
@@ -1300,6 +1300,7 @@ class TestDatabaseRequires(DataRequirerBaseTests, unittest.TestCase):
         data = self.harness.charm.requirer.fetch_my_relation_data()
         assert data == {
             self.rel_id: {
+                "alias": "cluster1",
                 "somedata": "somevalue",
                 "database": "data_platform",
                 "extra-user-roles": "CREATEDB,CREATEROLE",


### PR DESCRIPTION
# Issue

When a relation alias is provided it should be set not only on the unit relation data level, but also on the application relation data level