### PR TITLE
[DPE-1770] Focal compatibility for upgrade lib

### DIFF
--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -263,7 +263,7 @@ class ZooKeeperCharm(CharmBase):
 import json
 import logging
 from abc import ABC, abstractmethod
-from typing import List, Literal, Optional, Set, Tuple
+from typing import Dict, List, Literal, Optional, Set, Tuple
 
 import poetry.core.constraints.version as poetry_version
 from ops.charm import (
@@ -346,7 +346,7 @@ class DependencyModel(BaseModel):
         print(model.dict())  # exporting back validated deps
     """
 
-    dependencies: dict[str, str]
+    dependencies: Dict[str, str]
     name: str
     upgrade_supported: str
     version: str

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -285,7 +285,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 14
+LIBPATCH = 15
 
 PYDEPS = ["pydantic>=1.10,<2", "poetry-core"]
 


### PR DESCRIPTION
## Issue
Upgrade lib throws an exception on focal series charms: `TypeError: 'type' object is not subscriptable`

## Solution
Use Dict annotation
