### PR TITLE
[DPE-2828] Delete field from relation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,7 @@ jobs:
             juju-snap-channel: "2.9/stable"
             libjuju-version: "2.9.42.4"
           - juju-bootstrap-option: "3.1.6"
-            juju-snap-channel: "3.1/candidate"
+            juju-snap-channel: "3.1/stable"
             libjuju-version: "3.2.2"
     name: ${{ matrix.tox-environments }} Juju ${{ matrix.juju-version.juju-snap-channel}} -- libjuju ${{ matrix.juju-version.libjuju-version }}
     needs:

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -298,7 +298,7 @@ from abc import ABC, abstractmethod
 from collections import namedtuple
 from datetime import datetime
 from enum import Enum
-from typing import Dict, List, Optional, Set, Union
+from typing import Callable, Dict, List, Optional, Set, Tuple, Union
 
 from ops import JujuVersion, Secret, SecretInfo, SecretNotFoundError
 from ops.charm import (
@@ -622,6 +622,11 @@ class DataRelation(Object, ABC):
         """Fetch data available (directily or indirectly -- i.e. secrets) from the relation for owner/this_app."""
         raise NotImplementedError
 
+    @abstractmethod
+    def _update_relation_data(self, relation: Relation, data: Dict[str, str]) -> None:
+        """Update data available (directily or indirectly -- i.e. secrets) from the relation for owner/this_app."""
+        raise NotImplementedError
+
     # Internal helper methods
 
     @staticmethod
@@ -688,9 +693,9 @@ class DataRelation(Object, ABC):
                 secret_fieldnames_grouped.setdefault(SecretGroup.EXTRA, []).append(key)
         return secret_fieldnames_grouped
 
-    def _retrieve_group_secret_contents(
+    def _get_group_secret_contents(
         self,
-        relation_id: int,
+        relation: Relation,
         group: SecretGroup,
         secret_fields: Optional[Union[Set[str], List[str]]] = None,
     ) -> Dict[str, str]:
@@ -698,11 +703,28 @@ class DataRelation(Object, ABC):
         if not secret_fields:
             secret_fields = []
 
-        if (secret := self._get_relation_secret(relation_id, group)) and (
+        if (secret := self._get_relation_secret(relation.id, group)) and (
             secret_data := secret.get_content()
         ):
             return {k: v for k, v in secret_data.items() if k in secret_fields}
         return {}
+
+    @staticmethod
+    def _secret_content_grouped(
+        content: Dict[str, str], secret_fields: Set[str], group_mapping: SecretGroup
+    ) -> Dict[str, str]:
+        if group_mapping == SecretGroup.EXTRA:
+            return {
+                k: v
+                for k, v in content.items()
+                if k in secret_fields and k not in SECRET_LABEL_MAP.keys()
+            }
+
+        return {
+            k: v
+            for k, v in content.items()
+            if k in secret_fields and SECRET_LABEL_MAP.get(k) == group_mapping
+        }
 
     @juju_secrets_only
     def _get_relation_secret_data(
@@ -712,6 +734,38 @@ class DataRelation(Object, ABC):
         secret = self._get_relation_secret(relation_id, group_mapping, relation_name)
         if secret:
             return secret.get_content()
+
+    # Core operations on Relation Fields manipulations (regardless whether the field is in the databag or in a secret)
+    # Internal functions to be called directly from transparent public interface functions (+closely related helpers)
+
+    def _process_secret_fields(
+        self,
+        relation: Relation,
+        req_secret_fields: Optional[List[str]],
+        impacted_rel_fields: List[str],
+        operation: Callable,
+        second_chance_as_normal_field: bool = True,
+        *args,
+        **kwargs,
+    ) -> Tuple[Dict[str, str], Set[str]]:
+        """Isolate target secret fields of manipulation, and execute requested operation by Secret Group."""
+        result = {}
+        normal_fields = set(impacted_rel_fields)
+        if req_secret_fields and self.secrets_enabled:
+            normal_fields = normal_fields - set(req_secret_fields)
+            secret_fields = set(impacted_rel_fields) - set(normal_fields)
+
+            secret_fieldnames_grouped = self._group_secret_fields(list(secret_fields))
+
+            for group in secret_fieldnames_grouped:
+                # operation() should return nothing when all goes well
+                if group_result := operation(relation, group, secret_fields, *args, **kwargs):
+                    result.update(group_result)
+                elif second_chance_as_normal_field:
+                    # If it wasn't found as a secret, let's give it a 2nd chance as "normal" field
+                    # Needed when Juju3 Requires meets Juju2 Provider
+                    normal_fields |= set(secret_fieldnames_grouped[group])
+        return (result, normal_fields)
 
     def _fetch_relation_data_without_secrets(
         self, app: Application, relation: Relation, fields: Optional[List[str]]
@@ -743,43 +797,42 @@ class DataRelation(Object, ABC):
         Provides side itself).
         """
         result = {}
+        normal_fields = []
 
-        normal_fields = fields
-        if not normal_fields:
-            normal_fields = list(relation.data[app].keys())
+        if not fields:
+            all_fields = list(relation.data[app].keys())
+            normal_fields = [field for field in all_fields if not self._is_secret_field(field)]
 
-        if req_secret_fields and self.secrets_enabled:
-            if fields:
-                # Processing from what was requested
-                normal_fields = set(fields) - set(req_secret_fields)
-                secret_fields = set(fields) - set(normal_fields)
+            # There must have been secrets there
+            if all_fields != normal_fields and req_secret_fields:
+                # So we assemble the full fields list (without 'secret-<X>' fields)
+                fields = normal_fields + req_secret_fields
 
-                secret_fieldnames_grouped = self._group_secret_fields(list(secret_fields))
-
-                for group in secret_fieldnames_grouped:
-                    if contents := self._retrieve_group_secret_contents(
-                        relation.id, group, secret_fields
-                    ):
-                        result.update(contents)
-                    else:
-                        # If it wasn't found as a secret, let's give it a 2nd chance as "normal" field
-                        normal_fields |= set(secret_fieldnames_grouped[group])
-            else:
-                # Processing from what is given, i.e. retrieving all
-                normal_fields = [
-                    f for f in relation.data[app].keys() if not self._is_secret_field(f)
-                ]
-                secret_fields = [f for f in relation.data[app].keys() if self._is_secret_field(f)]
-                for group in SecretGroup:
-                    result.update(
-                        self._retrieve_group_secret_contents(relation.id, group, req_secret_fields)
-                    )
+        if fields:
+            result, normal_fields = self._process_secret_fields(
+                relation, req_secret_fields, fields, self._get_group_secret_contents
+            )
 
         # Processing "normal" fields. May include leftover from what we couldn't retrieve as a secret.
-        result.update({k: relation.data[app][k] for k in normal_fields if k in relation.data[app]})
+        # (Typically when Juju3 Requires meets Juju2 Provides)
+        if normal_fields:
+            result.update(
+                self._fetch_relation_data_without_secrets(app, relation, list(normal_fields))
+            )
         return result
 
-    # Public methods
+    def _update_relation_data_without_secrets(
+        self, app: Application, relation: Relation, data: Dict[str, str]
+    ):
+        """Updating databag contents when no secrets are involved."""
+        if any(self._is_secret_field(key) for key in data.keys()):
+            raise SecretsIllegalUpdateError("Can't update secret {key}.")
+
+        if relation:
+            relation.data[app].update(data)
+
+    # Public interface methods
+    # Handling Relation Fields seamlessly, regardless if in databag or a Juju Secret
 
     def get_relation(self, relation_name, relation_id) -> Relation:
         """Safe way of retrieving a relation."""
@@ -879,12 +932,12 @@ class DataRelation(Object, ABC):
         if relation_data := self.fetch_my_relation_data([relation_id], [field], relation_name):
             return relation_data.get(relation_id, {}).get(field)
 
-    # Public methods - mandatory override
-
-    @abstractmethod
+    @leader_only
     def update_relation_data(self, relation_id: int, data: dict) -> None:
         """Update the data within the relation."""
-        raise NotImplementedError
+        relation_name = self.relation_name
+        relation = self.get_relation(relation_name, relation_id)
+        return self._update_relation_data(relation, data)
 
 
 # Base DataProvides and DataRequires
@@ -910,36 +963,32 @@ class DataProvides(DataRelation):
 
     # Private methods handling secrets
 
-    @leader_only
     @juju_secrets_only
     def _add_relation_secret(
-        self, relation_id: int, content: Dict[str, str], group_mapping: SecretGroup
+        self, relation: Relation, content: Dict[str, str], group_mapping: SecretGroup
     ) -> Optional[Secret]:
         """Add a new Juju Secret that will be registered in the relation databag."""
-        relation = self.get_relation(self.relation_name, relation_id)
-
         secret_field = self._generate_secret_field_name(group_mapping)
         if relation.data[self.local_app].get(secret_field):
-            logging.error("Secret for relation %s already exists, not adding again", relation_id)
+            logging.error("Secret for relation %s already exists, not adding again", relation.id)
             return
 
-        label = self._generate_secret_label(self.relation_name, relation_id, group_mapping)
+        label = self._generate_secret_label(self.relation_name, relation.id, group_mapping)
         secret = self.secrets.add(label, content, relation)
 
         # According to lint we may not have a Secret ID
         if secret.meta and secret.meta.id:
             relation.data[self.local_app][secret_field] = secret.meta.id
 
-    @leader_only
     @juju_secrets_only
     def _update_relation_secret(
-        self, relation_id: int, content: Dict[str, str], group_mapping: SecretGroup
+        self, relation: Relation, content: Dict[str, str], group_mapping: SecretGroup
     ):
         """Update the contents of an existing Juju Secret, referred in the relation databag."""
-        secret = self._get_relation_secret(relation_id, group_mapping)
+        secret = self._get_relation_secret(relation.id, group_mapping)
 
         if not secret:
-            logging.error("Can't update secret for relation %s", relation_id)
+            logging.error("Can't update secret for relation %s", relation.id)
             return
 
         old_content = secret.get_content()
@@ -947,22 +996,14 @@ class DataProvides(DataRelation):
         full_content.update(content)
         secret.set_content(full_content)
 
-    @staticmethod
-    def _secret_content_grouped(
-        content: Dict[str, str], secret_fields: Set[str], group_mapping: SecretGroup
-    ) -> Dict[str, str]:
-        if group_mapping == SecretGroup.EXTRA:
-            return {
-                k: v
-                for k, v in content.items()
-                if k in secret_fields and k not in SECRET_LABEL_MAP.keys()
-            }
-
-        return {
-            k: v
-            for k, v in content.items()
-            if k in secret_fields and SECRET_LABEL_MAP.get(k) == group_mapping
-        }
+    def _add_or_update_relation_secrets(
+        self, relation: Relation, group: SecretGroup, secret_fields, data: Dict[str, str]
+    ) -> None:
+        secret_content = self._secret_content_grouped(data, secret_fields, group)
+        if self._get_relation_secret(relation.id, group):
+            self._update_relation_secret(relation, secret_content, group)
+        else:
+            self._add_relation_secret(relation, secret_content, group)
 
     # Mandatory internal overrides
 
@@ -1013,36 +1054,23 @@ class DataProvides(DataRelation):
             fields,
         )
 
-    # Public methods -- mandatory overrides
-
-    @leader_only
-    def update_relation_data(self, relation_id: int, fields: Dict[str, str]) -> None:
+    def _update_relation_data(self, relation: Relation, data: Dict[str, str]) -> None:
         """Set values for fields not caring whether it's a secret or not."""
-        relation = self.get_relation(self.relation_name, relation_id)
-
+        req_secret_fields = []
         if relation.app:
-            relation_secret_fields = get_encoded_field(relation, relation.app, REQ_SECRET_FIELDS)
-        else:
-            relation_secret_fields = []
+            req_secret_fields = get_encoded_field(relation, relation.app, REQ_SECRET_FIELDS)
+            req_secret_fields = req_secret_fields if isinstance(req_secret_fields, list) else None
 
-        normal_fields = list(fields)
-        if relation_secret_fields and self.secrets_enabled:
-            normal_fields = set(fields.keys()) - set(relation_secret_fields)
-            secret_fields = set(fields.keys()) - set(normal_fields)
-
-            secret_fieldnames_grouped = self._group_secret_fields(list(secret_fields))
-
-            for group in secret_fieldnames_grouped:
-                secret_content = self._secret_content_grouped(fields, secret_fields, group)
-                if self._get_relation_secret(relation_id, group):
-                    self._update_relation_secret(relation_id, secret_content, group)
-                else:
-                    self._add_relation_secret(relation_id, secret_content, group)
-
-        normal_content = {k: v for k, v in fields.items() if k in normal_fields}
-        relation.data[self.local_app].update(  # pyright: ignore [reportGeneralTypeIssues]
-            normal_content
+        _, normal_fields = self._process_secret_fields(
+            relation,
+            req_secret_fields,
+            list(data),
+            self._add_or_update_relation_secrets,
+            data=data,
         )
+
+        normal_content = {k: v for k, v in data.items() if k in normal_fields}
+        self._update_relation_data_without_secrets(self.local_app, relation, normal_content)
 
     # Public methods - "native"
 
@@ -1245,26 +1273,19 @@ class DataRequires(DataRelation):
         """Fetching our own relation data."""
         return self._fetch_relation_data_without_secrets(self.local_app, relation, fields)
 
-    # Public methods -- mandatory overrides
-
     @leader_only
-    def update_relation_data(self, relation_id: int, data: dict) -> None:
+    def _update_relation_data(self, relation: Relation, data: dict) -> None:
         """Updates a set of key-value pairs in the relation.
 
         This function writes in the application data bag, therefore,
         only the leader unit can call it.
 
         Args:
-            relation_id: the identifier for a particular relation.
+            relation: the particular relation.
             data: dict containing the key-value pairs
                 that should be updated in the relation.
         """
-        if any(self._is_secret_field(key) for key in data.keys()):
-            raise SecretsIllegalUpdateError("Requires side can't update secrets.")
-
-        relation = self.charm.model.get_relation(self.relation_name, relation_id)
-        if relation:
-            relation.data[self.local_app].update(data)
+        return self._update_relation_data_without_secrets(self.local_app, relation, data)
 
 
 # General events

--- a/tests/integration/application-charm/actions.yaml
+++ b/tests/integration/application-charm/actions.yaml
@@ -9,3 +9,18 @@ get-plugin-status:
 
 reset-unit-status:
   description: Set empty status message (ActiveStatus)
+
+set-relation-field:
+  description: Set fields from the second-database relation
+  field:
+    type: string
+    description: Relation field
+  value:
+    type: string
+    description: Value of the field to set
+
+delete-relation-field:
+  description: Delete fields from the sedond-database relation
+  field:
+    type: string
+    description: Relation field

--- a/tests/integration/application-charm/src/charm.py
+++ b/tests/integration/application-charm/src/charm.py
@@ -152,7 +152,7 @@ class ApplicationCharm(CharmBase):
 
     # Set/delete field
     def _on_set_relation_field(self, event: ActionEvent):
-        """[second_database]: Delete requested relation field."""
+        """[second_database]: Set requested relation field."""
         for relation in self.second_database.relations:
             self.second_database.update_relation_data(
                 relation.id, {event.params["field"]: event.params["value"]}

--- a/tests/integration/application-charm/src/charm.py
+++ b/tests/integration/application-charm/src/charm.py
@@ -141,10 +141,27 @@ class ApplicationCharm(CharmBase):
         # actions
 
         self.framework.observe(self.on.reset_unit_status_action, self._on_reset_unit_status)
+        self.framework.observe(self.on.set_relation_field_action, self._on_set_relation_field)
+        self.framework.observe(
+            self.on.delete_relation_field_action, self._on_delete_relation_field
+        )
 
     def _on_start(self, _) -> None:
         """Only sets an Active status."""
         self.unit.status = ActiveStatus()
+
+    # Set/delete field
+    def _on_set_relation_field(self, event: ActionEvent):
+        """[second_database]: Delete requested relation field."""
+        for relation in self.second_database.relations:
+            self.second_database.update_relation_data(
+                relation.id, {event.params["field"]: event.params["value"]}
+            )
+
+    def _on_delete_relation_field(self, event: ActionEvent):
+        """[second_database]: Delete requested relation field."""
+        for relation in self.second_database.relations:
+            self.second_database.delete_relation_data(relation.id, [event.params["field"]])
 
     # First database events observers.
     def _on_first_database_created(self, event: DatabaseCreatedEvent) -> None:

--- a/tests/integration/database-charm/actions.yaml
+++ b/tests/integration/database-charm/actions.yaml
@@ -9,3 +9,18 @@ set-secret:
     field:
       type: string
       description: The mapping name, i.e. what databag field ('secret-<mapping>') is to be changed
+
+set-relation-field:
+  description: Set fields from the relation
+  field:
+    type: string
+    description: Relation field
+  value:
+    type: string
+    description: Value of the field to set
+
+delete-relation-field:
+  description: Delete fields from the relation
+  field:
+    type: string
+    description: Relation field

--- a/tests/integration/database-charm/src/charm.py
+++ b/tests/integration/database-charm/src/charm.py
@@ -149,7 +149,7 @@ class DatabaseCharm(CharmBase):
         self.unit.status = ActiveStatus()
 
     def _on_set_relation_field(self, event: ActionEvent):
-        """Delete requested relation field."""
+        """Set requested relation field."""
         for relation in self.database.relations:
             self.database.update_relation_data(
                 relation.id, {event.params["field"]: event.params["value"]}

--- a/tests/integration/database-charm/src/charm.py
+++ b/tests/integration/database-charm/src/charm.py
@@ -49,6 +49,10 @@ class DatabaseCharm(CharmBase):
             self.on.change_admin_password_action, self._on_change_admin_password
         )
         self.framework.observe(self.on.set_secret_action, self._on_set_secret_action)
+        self.framework.observe(self.on.set_relation_field_action, self._on_set_relation_field)
+        self.framework.observe(
+            self.on.delete_relation_field_action, self._on_delete_relation_field
+        )
 
     def _on_change_admin_password(self, event: ActionEvent):
         """Change the admin password."""
@@ -143,6 +147,18 @@ class DatabaseCharm(CharmBase):
         self.database.set_version(event.relation.id, version)
 
         self.unit.status = ActiveStatus()
+
+    def _on_set_relation_field(self, event: ActionEvent):
+        """Delete requested relation field."""
+        for relation in self.database.relations:
+            self.database.update_relation_data(
+                relation.id, {event.params["field"]: event.params["value"]}
+            )
+
+    def _on_delete_relation_field(self, event: ActionEvent):
+        """Delete requested relation field."""
+        for relation in self.database.relations:
+            self.database.delete_relation_data(relation.id, [event.params["field"]])
 
     def _new_password(self) -> str:
         """Generate a random password string.

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -26,8 +26,7 @@ logger = logging.getLogger(__name__)
 APPLICATION_APP_NAME = "application"
 DATABASE_APP_NAME = "database"
 ANOTHER_DATABASE_APP_NAME = "another-database"
-# APP_NAMES = [APPLICATION_APP_NAME, DATABASE_APP_NAME, ANOTHER_DATABASE_APP_NAME]
-APP_NAMES = [APPLICATION_APP_NAME, DATABASE_APP_NAME]
+APP_NAMES = [APPLICATION_APP_NAME, DATABASE_APP_NAME, ANOTHER_DATABASE_APP_NAME]
 DATABASE_APP_METADATA = yaml.safe_load(
     Path("./tests/integration/database-charm/metadata.yaml").read_text()
 )


### PR DESCRIPTION
Adding `delete_relation_data()` function that allows to remove fields from the relation on request.

IT's NOT implemented as part of the update function, given the already existing complexity.
I.e. as we're already "cherry-picking" among input fields ("Is this in a secret?" "Is this in the databag?") we shouldn't further load this logic to even select whether `None` values may be supplied to indicate removal for real.... Ah, and don't forget to remove the secret if all fields deleted -- otherwise you get an error if saving an empty secret... 
Pls, no more spagetti than what we already have :-)

Instead it seems to make more sense to have a clean interface for deletion. If one wants to delete a field, (s)he should do that explicitly. Cleaner interface, cleaner code...