### PR TITLE
[DPE-2850][FIX] Secret content duplication AND rolling update safe

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,6 +70,12 @@ jobs:
           - juju-bootstrap-option: "3.1.6"
             juju-snap-channel: "3.1/stable"
             libjuju-version: "3.2.2"
+        include:
+          - {tox-environments: integration-upgrades,
+              juju-version:
+              {juju-snap-channel: "3.1/stable",
+                juju-bootstrap-option: "3.1.6",
+                libjuju-version: "3.2.2"}}
     name: ${{ matrix.tox-environments }} Juju ${{ matrix.juju-version.juju-snap-channel}} -- libjuju ${{ matrix.juju-version.libjuju-version }}
     needs:
       - lint

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -320,7 +320,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 21
+LIBPATCH = 22
 
 PYDEPS = ["ops>=2.0.0"]
 
@@ -763,12 +763,21 @@ class DataRelation(Object, ABC):
         req_secret_fields: Optional[List[str]],
         impacted_rel_fields: List[str],
         operation: Callable,
-        second_chance_as_normal_field: bool = True,
         *args,
         **kwargs,
     ) -> Tuple[Dict[str, str], Set[str]]:
         """Isolate target secret fields of manipulation, and execute requested operation by Secret Group."""
         result = {}
+
+        # If the relation started on a databag, we just stay on the databag
+        # (Rolling upgrades may result in a relation starting on databag, getting secrets enabled on-the-fly)
+        # self.local_app is sufficient to check (ignored if Requires, never has secrets -- works if Provides)
+        fallback_to_databag = (
+            req_secret_fields
+            and self.local_unit.is_leader()
+            and set(req_secret_fields) & set(relation.data[self.local_app])
+        )
+
         normal_fields = set(impacted_rel_fields)
         if req_secret_fields and self.secrets_enabled:
             normal_fields = normal_fields - set(req_secret_fields)
@@ -779,8 +788,10 @@ class DataRelation(Object, ABC):
             for group in secret_fieldnames_grouped:
                 # operation() should return nothing when all goes well
                 if group_result := operation(relation, group, secret_fields, *args, **kwargs):
-                    result.update(group_result)
-                elif second_chance_as_normal_field:
+                    # If "meaningful" data was returned, we take it. (Some 'operation'-s only return success/failure.)
+                    if isinstance(group_result, dict):
+                        result.update(group_result)
+                else:
                     # If it wasn't found as a secret, let's give it a 2nd chance as "normal" field
                     # Needed when Juju3 Requires meets Juju2 Provider
                     normal_fields |= set(secret_fieldnames_grouped[group])
@@ -999,12 +1010,12 @@ class DataProvides(DataRelation):
     @juju_secrets_only
     def _add_relation_secret(
         self, relation: Relation, content: Dict[str, str], group_mapping: SecretGroup
-    ) -> Optional[Secret]:
+    ) -> bool:
         """Add a new Juju Secret that will be registered in the relation databag."""
         secret_field = self._generate_secret_field_name(group_mapping)
         if relation.data[self.local_app].get(secret_field):
             logging.error("Secret for relation %s already exists, not adding again", relation.id)
-            return
+            return False
 
         label = self._generate_secret_label(self.relation_name, relation.id, group_mapping)
         secret = self.secrets.add(label, content, relation)
@@ -1013,21 +1024,27 @@ class DataProvides(DataRelation):
         if secret.meta and secret.meta.id:
             relation.data[self.local_app][secret_field] = secret.meta.id
 
+        # Return the content that was added
+        return True
+
     @juju_secrets_only
     def _update_relation_secret(
         self, relation: Relation, content: Dict[str, str], group_mapping: SecretGroup
-    ):
+    ) -> bool:
         """Update the contents of an existing Juju Secret, referred in the relation databag."""
         secret = self._get_relation_secret(relation.id, group_mapping)
 
         if not secret:
             logging.error("Can't update secret for relation %s", relation.id)
-            return
+            return False
 
         old_content = secret.get_content()
         full_content = copy.deepcopy(old_content)
         full_content.update(content)
         secret.set_content(full_content)
+
+        # Return True on success
+        return True
 
     def _add_or_update_relation_secrets(
         self,
@@ -1039,30 +1056,43 @@ class DataProvides(DataRelation):
         """Update contents for Secret group. If the Secret doesn't exist, create it."""
         secret_content = self._content_for_secret_group(data, secret_fields, group)
         if self._get_relation_secret(relation.id, group):
-            self._update_relation_secret(relation, secret_content, group)
+            return self._update_relation_secret(relation, secret_content, group)
         else:
-            self._add_relation_secret(relation, secret_content, group)
+            return self._add_relation_secret(relation, secret_content, group)
 
     @juju_secrets_only
     def _delete_relation_secret(
         self, relation: Relation, group: SecretGroup, secret_fields: List[str], fields: List[str]
-    ):
+    ) -> bool:
         """Update the contents of an existing Juju Secret, referred in the relation databag."""
         secret = self._get_relation_secret(relation.id, group)
 
         if not secret:
-            logging.error("Can't update secret for relation %s", relation.id)
-            return
+            logging.error("Can't update secret for relation %s", str(relation.id))
+            return False
 
         old_content = secret.get_content()
         new_content = copy.deepcopy(old_content)
         for field in fields:
-            new_content.pop(field)
+            try:
+                new_content.pop(field)
+            except KeyError:
+                logging.error(
+                    "Non-exsiting secret was attempted to be removed %s, %s",
+                    str(relation.id),
+                    str(field),
+                )
+                return False
+
         secret.set_content(new_content)
 
+        # Remove secret from the relation if it's fully gone
         if not new_content:
             field = self._generate_secret_field_name(group)
             relation.data[self.local_app].pop(field)
+
+        # Return the content that was removed
+        return True
 
     # Mandatory internal overrides
 

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -1078,7 +1078,7 @@ class DataProvides(DataRelation):
                 new_content.pop(field)
             except KeyError:
                 logging.error(
-                    "Non-exsiting secret was attempted to be removed %s, %s",
+                    "Non-existing secret was attempted to be removed %s, %s",
                     str(relation.id),
                     str(field),
                 )

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -779,7 +779,7 @@ class DataRelation(Object, ABC):
         )
 
         normal_fields = set(impacted_rel_fields)
-        if req_secret_fields and self.secrets_enabled:
+        if req_secret_fields and self.secrets_enabled and not fallback_to_databag:
             normal_fields = normal_fields - set(req_secret_fields)
             secret_fields = set(impacted_rel_fields) - set(normal_fields)
 
@@ -1052,7 +1052,7 @@ class DataProvides(DataRelation):
         group: SecretGroup,
         secret_fields: Set[str],
         data: Dict[str, str],
-    ) -> None:
+    ) -> bool:
         """Update contents for Secret group. If the Secret doesn't exist, create it."""
         secret_content = self._content_for_secret_group(data, secret_fields, group)
         if self._get_relation_secret(relation.id, group):

--- a/tests/integration/application-charm/actions.yaml
+++ b/tests/integration/application-charm/actions.yaml
@@ -10,6 +10,22 @@ get-plugin-status:
 reset-unit-status:
   description: Set empty status message (ActiveStatus)
 
+get-relation-field:
+  description: Get fields from the second-database relation
+  field:
+    type: string
+    description: Relation field
+
+get-relation-self-side-field:
+  description: Set fields from the relation
+  params:
+    relation_id:
+      type: integer 
+      description: The relation's unique ID
+    field:
+      type: string
+      description: Relation field
+
 set-relation-field:
   description: Set fields from the second-database relation
   field:

--- a/tests/integration/application-charm/src/charm.py
+++ b/tests/integration/application-charm/src/charm.py
@@ -9,11 +9,16 @@ of the libraries in this repository.
 """
 
 import logging
+from typing import Tuple
 
+from ops import Relation
 from ops.charm import ActionEvent, CharmBase
 from ops.main import main
 from ops.model import ActiveStatus
 
+from charms.data_platform_libs.v0.data_interfaces import (
+    LIBPATCH as DATA_INTERFACES_VERSION,
+)
 from charms.data_platform_libs.v0.data_interfaces import (
     BootstrapServerChangedEvent,
     DatabaseCreatedEvent,
@@ -60,13 +65,24 @@ class ApplicationCharm(CharmBase):
         # Events related to the second database that is requested
         # (these events are defined in the database requires charm library).
         database_name = f'{self.app.name.replace("-", "_")}_second_database'
-        self.second_database = DatabaseRequires(
-            self,
-            "second-database",
-            database_name,
-            EXTRA_USER_ROLES,
-            additional_secret_fields=["topsecret", "donttellanyone"],
-        )
+
+        # Keeping the charm backwards compatible, for upgrades testing
+        if DATA_INTERFACES_VERSION > 17:
+            self.second_database = DatabaseRequires(
+                self,
+                "second-database",
+                database_name,
+                EXTRA_USER_ROLES,
+                additional_secret_fields=["topsecret", "donttellanyone"],
+            )
+        else:
+            self.second_database = DatabaseRequires(
+                self,
+                "second-database",
+                database_name,
+                EXTRA_USER_ROLES,
+            )
+
         self.framework.observe(
             self.second_database.on.database_created, self._on_second_database_created
         )
@@ -141,27 +157,71 @@ class ApplicationCharm(CharmBase):
         # actions
 
         self.framework.observe(self.on.reset_unit_status_action, self._on_reset_unit_status)
+
+        # Get/set/delete fields on second-database relations
+        self.framework.observe(self.on.get_relation_field_action, self._on_get_relation_field)
+        self.framework.observe(
+            self.on.get_relation_self_side_field_action, self._on_get_relation_self_side_field
+        )
         self.framework.observe(self.on.set_relation_field_action, self._on_set_relation_field)
         self.framework.observe(
             self.on.delete_relation_field_action, self._on_delete_relation_field
         )
+        self._relation_endpoints = [
+            self.first_database,
+            self.second_database,
+            self.database_clusters,
+            self.aliased_database_clusters,
+            self.kafka,
+            self.opensearch,
+        ]
+
+    def _get_relation(self, relation_id: int) -> Tuple[CharmBase, Relation]:
+        for source in self._relation_endpoints:
+            for relation in source.relations:
+                if relation.id == relation_id:
+                    return (source, relation)
 
     def _on_start(self, _) -> None:
         """Only sets an Active status."""
         self.unit.status = ActiveStatus()
 
-    # Set/delete field
+    # Generic relation actions
+    def _on_get_relation_field(self, event: ActionEvent):
+        """Get requested relation field (OTHER side)."""
+        source, relation = self._get_relation(event.params["relation_id"])
+        if DATA_INTERFACES_VERSION > 17:
+            value = source.fetch_relation_field(relation.id, event.params["field"])
+        else:
+            value = relation.data[relation.app].get(event.params["field"])
+        event.set_results({"value": value if value else ""})
+
+    def _on_get_relation_self_side_field(self, event: ActionEvent):
+        """Get requested relation field (OTHER side)."""
+        source, relation = self._get_relation(event.params["relation_id"])
+        if DATA_INTERFACES_VERSION > 17:
+            value = source.fetch_my_relation_field(relation.id, event.params["field"])
+        else:
+            value = relation.data[source.local_app].get(event.params["field"])
+        event.set_results({"value": value if value else ""})
+
     def _on_set_relation_field(self, event: ActionEvent):
-        """[second_database]: Set requested relation field."""
-        for relation in self.second_database.relations:
-            self.second_database.update_relation_data(
+        """Set requested relation field on self-side (that's the only one writeable)."""
+        source, relation = self._get_relation(event.params["relation_id"])
+        if DATA_INTERFACES_VERSION > 17:
+            source.update_relation_data(
                 relation.id, {event.params["field"]: event.params["value"]}
             )
+        else:
+            relation.data[source.local_app][event.params["field"]] = event.params["value"]
 
     def _on_delete_relation_field(self, event: ActionEvent):
-        """[second_database]: Delete requested relation field."""
-        for relation in self.second_database.relations:
-            self.second_database.delete_relation_data(relation.id, [event.params["field"]])
+        """Delete requested relation field on self-side (that's the only one writeable)."""
+        source, relation = self._get_relation(event.params["relation_id"])
+        if DATA_INTERFACES_VERSION > 17:
+            source.delete_relation_data(relation.id, [event.params["field"]])
+        else:
+            del relation.data[source.local_app][event.params["field"]]
 
     # First database events observers.
     def _on_first_database_created(self, event: DatabaseCreatedEvent) -> None:

--- a/tests/integration/application-charm/src/charm.py
+++ b/tests/integration/application-charm/src/charm.py
@@ -9,7 +9,7 @@ of the libraries in this repository.
 """
 
 import logging
-from typing import Tuple
+from typing import Optional, Tuple
 
 from ops import Relation
 from ops.charm import ActionEvent, CharmBase
@@ -176,7 +176,8 @@ class ApplicationCharm(CharmBase):
             self.opensearch,
         ]
 
-    def _get_relation(self, relation_id: int) -> Tuple[CharmBase, Relation]:
+    def _get_relation(self, relation_id: int) -> Optional[Tuple[CharmBase, Relation]]:
+        """Retrieve a relation by ID, together with the corresponding endpoint object ('Requires')."""
         for source in self._relation_endpoints:
             for relation in source.relations:
                 if relation.id == relation_id:

--- a/tests/integration/data/data_interfaces.py
+++ b/tests/integration/data/data_interfaces.py
@@ -1,0 +1,1444 @@
+# Copyright 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""Library to manage the relation for the data-platform products.
+
+This library contains the Requires and Provides classes for handling the relation
+between an application and multiple managed application supported by the data-team:
+MySQL, Postgresql, MongoDB, Redis, and Kafka.
+
+### Database (MySQL, Postgresql, MongoDB, and Redis)
+
+#### Requires Charm
+This library is a uniform interface to a selection of common database
+metadata, with added custom events that add convenience to database management,
+and methods to consume the application related data.
+
+
+Following an example of using the DatabaseCreatedEvent, in the context of the
+application charm code:
+
+```python
+
+from charms.data_platform_libs.v0.data_interfaces import (
+    DatabaseCreatedEvent,
+    DatabaseRequires,
+)
+
+class ApplicationCharm(CharmBase):
+    # Application charm that connects to database charms.
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+        # Charm events defined in the database requires charm library.
+        self.database = DatabaseRequires(self, relation_name="database", database_name="database")
+        self.framework.observe(self.database.on.database_created, self._on_database_created)
+
+    def _on_database_created(self, event: DatabaseCreatedEvent) -> None:
+        # Handle the created database
+
+        # Create configuration file for app
+        config_file = self._render_app_config_file(
+            event.username,
+            event.password,
+            event.endpoints,
+        )
+
+        # Start application with rendered configuration
+        self._start_application(config_file)
+
+        # Set active status
+        self.unit.status = ActiveStatus("received database credentials")
+```
+
+As shown above, the library provides some custom events to handle specific situations,
+which are listed below:
+
+-  database_created: event emitted when the requested database is created.
+-  endpoints_changed: event emitted when the read/write endpoints of the database have changed.
+-  read_only_endpoints_changed: event emitted when the read-only endpoints of the database
+  have changed. Event is not triggered if read/write endpoints changed too.
+
+If it is needed to connect multiple database clusters to the same relation endpoint
+the application charm can implement the same code as if it would connect to only
+one database cluster (like the above code example).
+
+To differentiate multiple clusters connected to the same relation endpoint
+the application charm can use the name of the remote application:
+
+```python
+
+def _on_database_created(self, event: DatabaseCreatedEvent) -> None:
+    # Get the remote app name of the cluster that triggered this event
+    cluster = event.relation.app.name
+```
+
+It is also possible to provide an alias for each different database cluster/relation.
+
+So, it is possible to differentiate the clusters in two ways.
+The first is to use the remote application name, i.e., `event.relation.app.name`, as above.
+
+The second way is to use different event handlers to handle each cluster events.
+The implementation would be something like the following code:
+
+```python
+
+from charms.data_platform_libs.v0.data_interfaces import (
+    DatabaseCreatedEvent,
+    DatabaseRequires,
+)
+
+class ApplicationCharm(CharmBase):
+    # Application charm that connects to database charms.
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+        # Define the cluster aliases and one handler for each cluster database created event.
+        self.database = DatabaseRequires(
+            self,
+            relation_name="database",
+            database_name="database",
+            relations_aliases = ["cluster1", "cluster2"],
+        )
+        self.framework.observe(
+            self.database.on.cluster1_database_created, self._on_cluster1_database_created
+        )
+        self.framework.observe(
+            self.database.on.cluster2_database_created, self._on_cluster2_database_created
+        )
+
+    def _on_cluster1_database_created(self, event: DatabaseCreatedEvent) -> None:
+        # Handle the created database on the cluster named cluster1
+
+        # Create configuration file for app
+        config_file = self._render_app_config_file(
+            event.username,
+            event.password,
+            event.endpoints,
+        )
+        ...
+
+    def _on_cluster2_database_created(self, event: DatabaseCreatedEvent) -> None:
+        # Handle the created database on the cluster named cluster2
+
+        # Create configuration file for app
+        config_file = self._render_app_config_file(
+            event.username,
+            event.password,
+            event.endpoints,
+        )
+        ...
+
+```
+
+When it's needed to check whether a plugin (extension) is enabled on the PostgreSQL
+charm, you can use the is_postgresql_plugin_enabled method. To use that, you need to
+add the following dependency to your charmcraft.yaml file:
+
+```yaml
+
+parts:
+  charm:
+    charm-binary-python-packages:
+      - psycopg[binary]
+
+```
+
+### Provider Charm
+
+Following an example of using the DatabaseRequestedEvent, in the context of the
+database charm code:
+
+```python
+from charms.data_platform_libs.v0.data_interfaces import DatabaseProvides
+
+class SampleCharm(CharmBase):
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        # Charm events defined in the database provides charm library.
+        self.provided_database = DatabaseProvides(self, relation_name="database")
+        self.framework.observe(self.provided_database.on.database_requested,
+            self._on_database_requested)
+        # Database generic helper
+        self.database = DatabaseHelper()
+
+    def _on_database_requested(self, event: DatabaseRequestedEvent) -> None:
+        # Handle the event triggered by a new database requested in the relation
+        # Retrieve the database name using the charm library.
+        db_name = event.database
+        # generate a new user credential
+        username = self.database.generate_user()
+        password = self.database.generate_password()
+        # set the credentials for the relation
+        self.provided_database.set_credentials(event.relation.id, username, password)
+        # set other variables for the relation event.set_tls("False")
+```
+As shown above, the library provides a custom event (database_requested) to handle
+the situation when an application charm requests a new database to be created.
+It's preferred to subscribe to this event instead of relation changed event to avoid
+creating a new database when other information other than a database name is
+exchanged in the relation databag.
+
+### Kafka
+
+This library is the interface to use and interact with the Kafka charm. This library contains
+custom events that add convenience to manage Kafka, and provides methods to consume the
+application related data.
+
+#### Requirer Charm
+
+```python
+
+from charms.data_platform_libs.v0.data_interfaces import (
+    BootstrapServerChangedEvent,
+    KafkaRequires,
+    TopicCreatedEvent,
+)
+
+class ApplicationCharm(CharmBase):
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.kafka = KafkaRequires(self, "kafka_client", "test-topic")
+        self.framework.observe(
+            self.kafka.on.bootstrap_server_changed, self._on_kafka_bootstrap_server_changed
+        )
+        self.framework.observe(
+            self.kafka.on.topic_created, self._on_kafka_topic_created
+        )
+
+    def _on_kafka_bootstrap_server_changed(self, event: BootstrapServerChangedEvent):
+        # Event triggered when a bootstrap server was changed for this application
+
+        new_bootstrap_server = event.bootstrap_server
+        ...
+
+    def _on_kafka_topic_created(self, event: TopicCreatedEvent):
+        # Event triggered when a topic was created for this application
+        username = event.username
+        password = event.password
+        tls = event.tls
+        tls_ca= event.tls_ca
+        bootstrap_server event.bootstrap_server
+        consumer_group_prefic = event.consumer_group_prefix
+        zookeeper_uris = event.zookeeper_uris
+        ...
+
+```
+
+As shown above, the library provides some custom events to handle specific situations,
+which are listed below:
+
+- topic_created: event emitted when the requested topic is created.
+- bootstrap_server_changed: event emitted when the bootstrap server have changed.
+- credential_changed: event emitted when the credentials of Kafka changed.
+
+### Provider Charm
+
+Following the previous example, this is an example of the provider charm.
+
+```python
+class SampleCharm(CharmBase):
+
+from charms.data_platform_libs.v0.data_interfaces import (
+    KafkaProvides,
+    TopicRequestedEvent,
+)
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+        # Default charm events.
+        self.framework.observe(self.on.start, self._on_start)
+
+        # Charm events defined in the Kafka Provides charm library.
+        self.kafka_provider = KafkaProvides(self, relation_name="kafka_client")
+        self.framework.observe(self.kafka_provider.on.topic_requested, self._on_topic_requested)
+        # Kafka generic helper
+        self.kafka = KafkaHelper()
+
+    def _on_topic_requested(self, event: TopicRequestedEvent):
+        # Handle the on_topic_requested event.
+
+        topic = event.topic
+        relation_id = event.relation.id
+        # set connection info in the databag relation
+        self.kafka_provider.set_bootstrap_server(relation_id, self.kafka.get_bootstrap_server())
+        self.kafka_provider.set_credentials(relation_id, username=username, password=password)
+        self.kafka_provider.set_consumer_group_prefix(relation_id, ...)
+        self.kafka_provider.set_tls(relation_id, "False")
+        self.kafka_provider.set_zookeeper_uris(relation_id, ...)
+
+```
+As shown above, the library provides a custom event (topic_requested) to handle
+the situation when an application charm requests a new topic to be created.
+It is preferred to subscribe to this event instead of relation changed event to avoid
+creating a new topic when other information other than a topic name is
+exchanged in the relation databag.
+"""
+
+import json
+import logging
+from abc import ABC, abstractmethod
+from collections import namedtuple
+from datetime import datetime
+from typing import List, Optional, Union
+
+from ops.charm import (
+    CharmBase,
+    CharmEvents,
+    RelationChangedEvent,
+    RelationCreatedEvent,
+    RelationEvent,
+)
+from ops.framework import EventSource, Object
+from ops.model import Application, ModelError, Relation, Unit
+
+# The unique Charmhub library identifier, never change it
+LIBID = "6c3e6b6680d64e9c89e611d1a15f65be"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 17
+
+PYDEPS = ["ops>=2.0.0"]
+
+logger = logging.getLogger(__name__)
+
+Diff = namedtuple("Diff", "added changed deleted")
+Diff.__doc__ = """
+A tuple for storing the diff between two data mappings.
+
+added - keys that were added
+changed - keys that still exist but have new values
+deleted - key that were deleted"""
+
+
+def diff(event: RelationChangedEvent, bucket: Union[Unit, Application]) -> Diff:
+    """Retrieves the diff of the data in the relation changed databag.
+
+    Args:
+        event: relation changed event.
+        bucket: bucket of the databag (app or unit)
+
+    Returns:
+        a Diff instance containing the added, deleted and changed
+            keys from the event relation databag.
+    """
+    # Retrieve the old data from the data key in the application relation databag.
+    old_data = json.loads(event.relation.data[bucket].get("data", "{}"))
+    # Retrieve the new data from the event relation databag.
+    new_data = (
+        {key: value for key, value in event.relation.data[event.app].items() if key != "data"}
+        if event.app
+        else {}
+    )
+
+    # These are the keys that were added to the databag and triggered this event.
+    added = new_data.keys() - old_data.keys()
+    # These are the keys that were removed from the databag and triggered this event.
+    deleted = old_data.keys() - new_data.keys()
+    # These are the keys that already existed in the databag,
+    # but had their values changed.
+    changed = {key for key in old_data.keys() & new_data.keys() if old_data[key] != new_data[key]}
+    # Convert the new_data to a serializable format and save it for a next diff check.
+    event.relation.data[bucket].update({"data": json.dumps(new_data)})
+
+    # Return the diff with all possible changes.
+    return Diff(added, changed, deleted)
+
+
+# Base DataRelation
+
+
+class DataRelation(Object, ABC):
+    """Base relation data mainpulation class."""
+
+    def __init__(self, charm: CharmBase, relation_name: str) -> None:
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.local_app = self.charm.model.app
+        self.local_unit = self.charm.unit
+        self.relation_name = relation_name
+        self.framework.observe(
+            charm.on[relation_name].relation_changed,
+            self._on_relation_changed_event,
+        )
+
+    @abstractmethod
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the relation data has changed."""
+        raise NotImplementedError
+
+    def fetch_relation_data(self) -> dict:
+        """Retrieves data from relation.
+
+        This function can be used to retrieve data from a relation
+        in the charm code when outside an event callback.
+        Function cannot be used in `*-relation-broken` events and will raise an exception.
+
+        Returns:
+            a dict of the values stored in the relation data bag
+                for all relation instances (indexed by the relation ID).
+        """
+        data = {}
+        for relation in self.relations:
+            data[relation.id] = (
+                {key: value for key, value in relation.data[relation.app].items() if key != "data"}
+                if relation.app
+                else {}
+            )
+        return data
+
+    def _update_relation_data(self, relation_id: int, data: dict) -> None:
+        """Updates a set of key-value pairs in the relation.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            data: dict containing the key-value pairs
+                that should be updated in the relation.
+        """
+        if self.local_unit.is_leader():
+            relation = self.charm.model.get_relation(self.relation_name, relation_id)
+            if relation:
+                relation.data[self.local_app].update(data)
+
+    @staticmethod
+    def _is_relation_active(relation: Relation):
+        """Whether the relation is active based on contained data."""
+        try:
+            _ = repr(relation.data)
+            return True
+        except (RuntimeError, ModelError):
+            return False
+
+    @property
+    def relations(self) -> List[Relation]:
+        """The list of Relation instances associated with this relation_name."""
+        return [
+            relation
+            for relation in self.charm.model.relations[self.relation_name]
+            if self._is_relation_active(relation)
+        ]
+
+
+# Base DataProvides and DataRequires
+
+
+class DataProvides(DataRelation):
+    """Base provides-side of the data products relation."""
+
+    def __init__(self, charm: CharmBase, relation_name: str) -> None:
+        super().__init__(charm, relation_name)
+
+    def _diff(self, event: RelationChangedEvent) -> Diff:
+        """Retrieves the diff of the data in the relation changed databag.
+
+        Args:
+            event: relation changed event.
+
+        Returns:
+            a Diff instance containing the added, deleted and changed
+                keys from the event relation databag.
+        """
+        return diff(event, self.local_app)
+
+    def set_credentials(self, relation_id: int, username: str, password: str) -> None:
+        """Set credentials.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            username: user that was created.
+            password: password of the created user.
+        """
+        self._update_relation_data(
+            relation_id,
+            {
+                "username": username,
+                "password": password,
+            },
+        )
+
+    def set_tls(self, relation_id: int, tls: str) -> None:
+        """Set whether TLS is enabled.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            tls: whether tls is enabled (True or False).
+        """
+        self._update_relation_data(relation_id, {"tls": tls})
+
+    def set_tls_ca(self, relation_id: int, tls_ca: str) -> None:
+        """Set the TLS CA in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            tls_ca: TLS certification authority.
+        """
+        self._update_relation_data(relation_id, {"tls-ca": tls_ca})
+
+
+class DataRequires(DataRelation):
+    """Requires-side of the relation."""
+
+    def __init__(
+        self,
+        charm,
+        relation_name: str,
+        extra_user_roles: Optional[str] = None,
+    ):
+        """Manager of base client relations."""
+        super().__init__(charm, relation_name)
+        self.extra_user_roles = extra_user_roles
+        self.framework.observe(
+            self.charm.on[relation_name].relation_created, self._on_relation_created_event
+        )
+
+    @abstractmethod
+    def _on_relation_created_event(self, event: RelationCreatedEvent) -> None:
+        """Event emitted when the relation is created."""
+        raise NotImplementedError
+
+    def _diff(self, event: RelationChangedEvent) -> Diff:
+        """Retrieves the diff of the data in the relation changed databag.
+
+        Args:
+            event: relation changed event.
+
+        Returns:
+            a Diff instance containing the added, deleted and changed
+                keys from the event relation databag.
+        """
+        return diff(event, self.local_unit)
+
+    @staticmethod
+    def _is_resource_created_for_relation(relation: Relation) -> bool:
+        if not relation.app:
+            return False
+
+        return (
+            "username" in relation.data[relation.app] and "password" in relation.data[relation.app]
+        )
+
+    def is_resource_created(self, relation_id: Optional[int] = None) -> bool:
+        """Check if the resource has been created.
+
+        This function can be used to check if the Provider answered with data in the charm code
+        when outside an event callback.
+
+        Args:
+            relation_id (int, optional): When provided the check is done only for the relation id
+                provided, otherwise the check is done for all relations
+
+        Returns:
+            True or False
+
+        Raises:
+            IndexError: If relation_id is provided but that relation does not exist
+        """
+        if relation_id is not None:
+            try:
+                relation = [relation for relation in self.relations if relation.id == relation_id][
+                    0
+                ]
+                return self._is_resource_created_for_relation(relation)
+            except IndexError:
+                raise IndexError(f"relation id {relation_id} cannot be accessed")
+        else:
+            return (
+                all(
+                    self._is_resource_created_for_relation(relation) for relation in self.relations
+                )
+                if self.relations
+                else False
+            )
+
+
+# General events
+
+
+class ExtraRoleEvent(RelationEvent):
+    """Base class for data events."""
+
+    @property
+    def extra_user_roles(self) -> Optional[str]:
+        """Returns the extra user roles that were requested."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("extra-user-roles")
+
+
+class AuthenticationEvent(RelationEvent):
+    """Base class for authentication fields for events."""
+
+    @property
+    def username(self) -> Optional[str]:
+        """Returns the created username."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("username")
+
+    @property
+    def password(self) -> Optional[str]:
+        """Returns the password for the created user."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("password")
+
+    @property
+    def tls(self) -> Optional[str]:
+        """Returns whether TLS is configured."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("tls")
+
+    @property
+    def tls_ca(self) -> Optional[str]:
+        """Returns TLS CA."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("tls-ca")
+
+
+# Database related events and fields
+
+
+class DatabaseProvidesEvent(RelationEvent):
+    """Base class for database events."""
+
+    @property
+    def database(self) -> Optional[str]:
+        """Returns the database that was requested."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("database")
+
+
+class DatabaseRequestedEvent(DatabaseProvidesEvent, ExtraRoleEvent):
+    """Event emitted when a new database is requested for use on this relation."""
+
+
+class DatabaseProvidesEvents(CharmEvents):
+    """Database events.
+
+    This class defines the events that the database can emit.
+    """
+
+    database_requested = EventSource(DatabaseRequestedEvent)
+
+
+class DatabaseRequiresEvent(RelationEvent):
+    """Base class for database events."""
+
+    @property
+    def database(self) -> Optional[str]:
+        """Returns the database name."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("database")
+
+    @property
+    def endpoints(self) -> Optional[str]:
+        """Returns a comma separated list of read/write endpoints.
+
+        In VM charms, this is the primary's address.
+        In kubernetes charms, this is the service to the primary pod.
+        """
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("endpoints")
+
+    @property
+    def read_only_endpoints(self) -> Optional[str]:
+        """Returns a comma separated list of read only endpoints.
+
+        In VM charms, this is the address of all the secondary instances.
+        In kubernetes charms, this is the service to all replica pod instances.
+        """
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("read-only-endpoints")
+
+    @property
+    def replset(self) -> Optional[str]:
+        """Returns the replicaset name.
+
+        MongoDB only.
+        """
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("replset")
+
+    @property
+    def uris(self) -> Optional[str]:
+        """Returns the connection URIs.
+
+        MongoDB, Redis, OpenSearch.
+        """
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("uris")
+
+    @property
+    def version(self) -> Optional[str]:
+        """Returns the version of the database.
+
+        Version as informed by the database daemon.
+        """
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("version")
+
+
+class DatabaseCreatedEvent(AuthenticationEvent, DatabaseRequiresEvent):
+    """Event emitted when a new database is created for use on this relation."""
+
+
+class DatabaseEndpointsChangedEvent(AuthenticationEvent, DatabaseRequiresEvent):
+    """Event emitted when the read/write endpoints are changed."""
+
+
+class DatabaseReadOnlyEndpointsChangedEvent(AuthenticationEvent, DatabaseRequiresEvent):
+    """Event emitted when the read only endpoints are changed."""
+
+
+class DatabaseRequiresEvents(CharmEvents):
+    """Database events.
+
+    This class defines the events that the database can emit.
+    """
+
+    database_created = EventSource(DatabaseCreatedEvent)
+    endpoints_changed = EventSource(DatabaseEndpointsChangedEvent)
+    read_only_endpoints_changed = EventSource(DatabaseReadOnlyEndpointsChangedEvent)
+
+
+# Database Provider and Requires
+
+
+class DatabaseProvides(DataProvides):
+    """Provider-side of the database relations."""
+
+    on = DatabaseProvidesEvents()  # pyright: ignore [reportGeneralTypeIssues]
+
+    def __init__(self, charm: CharmBase, relation_name: str) -> None:
+        super().__init__(charm, relation_name)
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the relation has changed."""
+        # Only the leader should handle this event.
+        if not self.local_unit.is_leader():
+            return
+
+        # Check which data has changed to emit customs events.
+        diff = self._diff(event)
+
+        # Emit a database requested event if the setup key (database name and optional
+        # extra user roles) was added to the relation databag by the application.
+        if "database" in diff.added:
+            getattr(self.on, "database_requested").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+    def set_database(self, relation_id: int, database_name: str) -> None:
+        """Set database name.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            database_name: database name.
+        """
+        self._update_relation_data(relation_id, {"database": database_name})
+
+    def set_endpoints(self, relation_id: int, connection_strings: str) -> None:
+        """Set database primary connections.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        In VM charms, only the primary's address should be passed as an endpoint.
+        In kubernetes charms, the service endpoint to the primary pod should be
+        passed as an endpoint.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            connection_strings: database hosts and ports comma separated list.
+        """
+        self._update_relation_data(relation_id, {"endpoints": connection_strings})
+
+    def set_read_only_endpoints(self, relation_id: int, connection_strings: str) -> None:
+        """Set database replicas connection strings.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            connection_strings: database hosts and ports comma separated list.
+        """
+        self._update_relation_data(relation_id, {"read-only-endpoints": connection_strings})
+
+    def set_replset(self, relation_id: int, replset: str) -> None:
+        """Set replica set name in the application relation databag.
+
+        MongoDB only.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            replset: replica set name.
+        """
+        self._update_relation_data(relation_id, {"replset": replset})
+
+    def set_uris(self, relation_id: int, uris: str) -> None:
+        """Set the database connection URIs in the application relation databag.
+
+        MongoDB, Redis, and OpenSearch only.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            uris: connection URIs.
+        """
+        self._update_relation_data(relation_id, {"uris": uris})
+
+    def set_version(self, relation_id: int, version: str) -> None:
+        """Set the database version in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            version: database version.
+        """
+        self._update_relation_data(relation_id, {"version": version})
+
+
+class DatabaseRequires(DataRequires):
+    """Requires-side of the database relation."""
+
+    on = DatabaseRequiresEvents()  # pyright: ignore [reportGeneralTypeIssues]
+
+    def __init__(
+        self,
+        charm,
+        relation_name: str,
+        database_name: str,
+        extra_user_roles: Optional[str] = None,
+        relations_aliases: Optional[List[str]] = None,
+    ):
+        """Manager of database client relations."""
+        super().__init__(charm, relation_name, extra_user_roles)
+        self.database = database_name
+        self.relations_aliases = relations_aliases
+
+        # Define custom event names for each alias.
+        if relations_aliases:
+            # Ensure the number of aliases does not exceed the maximum
+            # of connections allowed in the specific relation.
+            relation_connection_limit = self.charm.meta.requires[relation_name].limit
+            if len(relations_aliases) != relation_connection_limit:
+                raise ValueError(
+                    f"The number of aliases must match the maximum number of connections allowed in the relation. "
+                    f"Expected {relation_connection_limit}, got {len(relations_aliases)}"
+                )
+
+            for relation_alias in relations_aliases:
+                self.on.define_event(f"{relation_alias}_database_created", DatabaseCreatedEvent)
+                self.on.define_event(
+                    f"{relation_alias}_endpoints_changed", DatabaseEndpointsChangedEvent
+                )
+                self.on.define_event(
+                    f"{relation_alias}_read_only_endpoints_changed",
+                    DatabaseReadOnlyEndpointsChangedEvent,
+                )
+
+    def _assign_relation_alias(self, relation_id: int) -> None:
+        """Assigns an alias to a relation.
+
+        This function writes in the unit data bag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+        """
+        # If no aliases were provided, return immediately.
+        if not self.relations_aliases:
+            return
+
+        # Return if an alias was already assigned to this relation
+        # (like when there are more than one unit joining the relation).
+        relation = self.charm.model.get_relation(self.relation_name, relation_id)
+        if relation and relation.data[self.local_unit].get("alias"):
+            return
+
+        # Retrieve the available aliases (the ones that weren't assigned to any relation).
+        available_aliases = self.relations_aliases[:]
+        for relation in self.charm.model.relations[self.relation_name]:
+            alias = relation.data[self.local_unit].get("alias")
+            if alias:
+                logger.debug("Alias %s was already assigned to relation %d", alias, relation.id)
+                available_aliases.remove(alias)
+
+        # Set the alias in the unit relation databag of the specific relation.
+        relation = self.charm.model.get_relation(self.relation_name, relation_id)
+        if relation:
+            relation.data[self.local_unit].update({"alias": available_aliases[0]})
+
+    def _emit_aliased_event(self, event: RelationChangedEvent, event_name: str) -> None:
+        """Emit an aliased event to a particular relation if it has an alias.
+
+        Args:
+            event: the relation changed event that was received.
+            event_name: the name of the event to emit.
+        """
+        alias = self._get_relation_alias(event.relation.id)
+        if alias:
+            getattr(self.on, f"{alias}_{event_name}").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+    def _get_relation_alias(self, relation_id: int) -> Optional[str]:
+        """Returns the relation alias.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+
+        Returns:
+            the relation alias or None if the relation was not found.
+        """
+        for relation in self.charm.model.relations[self.relation_name]:
+            if relation.id == relation_id:
+                return relation.data[self.local_unit].get("alias")
+        return None
+
+    def is_postgresql_plugin_enabled(self, plugin: str, relation_index: int = 0) -> bool:
+        """Returns whether a plugin is enabled in the database.
+
+        Args:
+            plugin: name of the plugin to check.
+            relation_index: optional relation index to check the database
+                (default: 0 - first relation).
+
+        PostgreSQL only.
+        """
+        # Psycopg 3 is imported locally to avoid the need of its package installation
+        # when relating to a database charm other than PostgreSQL.
+        import psycopg
+
+        # Return False if no relation is established.
+        if len(self.relations) == 0:
+            return False
+
+        relation_data = self.fetch_relation_data()[self.relations[relation_index].id]
+        host = relation_data.get("endpoints")
+
+        # Return False if there is no endpoint available.
+        if host is None:
+            return False
+
+        host = host.split(":")[0]
+        user = relation_data.get("username")
+        password = relation_data.get("password")
+        connection_string = (
+            f"host='{host}' dbname='{self.database}' user='{user}' password='{password}'"
+        )
+        try:
+            with psycopg.connect(connection_string) as connection:
+                with connection.cursor() as cursor:
+                    cursor.execute(
+                        "SELECT TRUE FROM pg_extension WHERE extname=%s::text;", (plugin,)
+                    )
+                    return cursor.fetchone() is not None
+        except psycopg.Error as e:
+            logger.exception(
+                f"failed to check whether {plugin} plugin is enabled in the database: %s", str(e)
+            )
+            return False
+
+    def _on_relation_created_event(self, event: RelationCreatedEvent) -> None:
+        """Event emitted when the database relation is created."""
+        # If relations aliases were provided, assign one to the relation.
+        self._assign_relation_alias(event.relation.id)
+
+        # Sets both database and extra user roles in the relation
+        # if the roles are provided. Otherwise, sets only the database.
+        if self.extra_user_roles:
+            self._update_relation_data(
+                event.relation.id,
+                {
+                    "database": self.database,
+                    "extra-user-roles": self.extra_user_roles,
+                },
+            )
+        else:
+            self._update_relation_data(event.relation.id, {"database": self.database})
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the database relation has changed."""
+        # Check which data has changed to emit customs events.
+        diff = self._diff(event)
+
+        # Check if the database is created
+        # (the database charm shared the credentials).
+        if "username" in diff.added and "password" in diff.added:
+            # Emit the default event (the one without an alias).
+            logger.info("database created at %s", datetime.now())
+            getattr(self.on, "database_created").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # Emit the aliased event (if any).
+            self._emit_aliased_event(event, "database_created")
+
+            # To avoid unnecessary application restarts do not trigger
+            # “endpoints_changed“ event if “database_created“ is triggered.
+            return
+
+        # Emit an endpoints changed event if the database
+        # added or changed this info in the relation databag.
+        if "endpoints" in diff.added or "endpoints" in diff.changed:
+            # Emit the default event (the one without an alias).
+            logger.info("endpoints changed on %s", datetime.now())
+            getattr(self.on, "endpoints_changed").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # Emit the aliased event (if any).
+            self._emit_aliased_event(event, "endpoints_changed")
+
+            # To avoid unnecessary application restarts do not trigger
+            # “read_only_endpoints_changed“ event if “endpoints_changed“ is triggered.
+            return
+
+        # Emit a read only endpoints changed event if the database
+        # added or changed this info in the relation databag.
+        if "read-only-endpoints" in diff.added or "read-only-endpoints" in diff.changed:
+            # Emit the default event (the one without an alias).
+            logger.info("read-only-endpoints changed on %s", datetime.now())
+            getattr(self.on, "read_only_endpoints_changed").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+            # Emit the aliased event (if any).
+            self._emit_aliased_event(event, "read_only_endpoints_changed")
+
+
+# Kafka related events
+
+
+class KafkaProvidesEvent(RelationEvent):
+    """Base class for Kafka events."""
+
+    @property
+    def topic(self) -> Optional[str]:
+        """Returns the topic that was requested."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("topic")
+
+    @property
+    def consumer_group_prefix(self) -> Optional[str]:
+        """Returns the consumer-group-prefix that was requested."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("consumer-group-prefix")
+
+
+class TopicRequestedEvent(KafkaProvidesEvent, ExtraRoleEvent):
+    """Event emitted when a new topic is requested for use on this relation."""
+
+
+class KafkaProvidesEvents(CharmEvents):
+    """Kafka events.
+
+    This class defines the events that the Kafka can emit.
+    """
+
+    topic_requested = EventSource(TopicRequestedEvent)
+
+
+class KafkaRequiresEvent(RelationEvent):
+    """Base class for Kafka events."""
+
+    @property
+    def topic(self) -> Optional[str]:
+        """Returns the topic."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("topic")
+
+    @property
+    def bootstrap_server(self) -> Optional[str]:
+        """Returns a comma-separated list of broker uris."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("endpoints")
+
+    @property
+    def consumer_group_prefix(self) -> Optional[str]:
+        """Returns the consumer-group-prefix."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("consumer-group-prefix")
+
+    @property
+    def zookeeper_uris(self) -> Optional[str]:
+        """Returns a comma separated list of Zookeeper uris."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("zookeeper-uris")
+
+
+class TopicCreatedEvent(AuthenticationEvent, KafkaRequiresEvent):
+    """Event emitted when a new topic is created for use on this relation."""
+
+
+class BootstrapServerChangedEvent(AuthenticationEvent, KafkaRequiresEvent):
+    """Event emitted when the bootstrap server is changed."""
+
+
+class KafkaRequiresEvents(CharmEvents):
+    """Kafka events.
+
+    This class defines the events that the Kafka can emit.
+    """
+
+    topic_created = EventSource(TopicCreatedEvent)
+    bootstrap_server_changed = EventSource(BootstrapServerChangedEvent)
+
+
+# Kafka Provides and Requires
+
+
+class KafkaProvides(DataProvides):
+    """Provider-side of the Kafka relation."""
+
+    on = KafkaProvidesEvents()  # pyright: ignore [reportGeneralTypeIssues]
+
+    def __init__(self, charm: CharmBase, relation_name: str) -> None:
+        super().__init__(charm, relation_name)
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the relation has changed."""
+        # Only the leader should handle this event.
+        if not self.local_unit.is_leader():
+            return
+
+        # Check which data has changed to emit customs events.
+        diff = self._diff(event)
+
+        # Emit a topic requested event if the setup key (topic name and optional
+        # extra user roles) was added to the relation databag by the application.
+        if "topic" in diff.added:
+            getattr(self.on, "topic_requested").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+    def set_topic(self, relation_id: int, topic: str) -> None:
+        """Set topic name in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            topic: the topic name.
+        """
+        self._update_relation_data(relation_id, {"topic": topic})
+
+    def set_bootstrap_server(self, relation_id: int, bootstrap_server: str) -> None:
+        """Set the bootstrap server in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            bootstrap_server: the bootstrap server address.
+        """
+        self._update_relation_data(relation_id, {"endpoints": bootstrap_server})
+
+    def set_consumer_group_prefix(self, relation_id: int, consumer_group_prefix: str) -> None:
+        """Set the consumer group prefix in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            consumer_group_prefix: the consumer group prefix string.
+        """
+        self._update_relation_data(relation_id, {"consumer-group-prefix": consumer_group_prefix})
+
+    def set_zookeeper_uris(self, relation_id: int, zookeeper_uris: str) -> None:
+        """Set the zookeeper uris in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            zookeeper_uris: comma-separated list of ZooKeeper server uris.
+        """
+        self._update_relation_data(relation_id, {"zookeeper-uris": zookeeper_uris})
+
+
+class KafkaRequires(DataRequires):
+    """Requires-side of the Kafka relation."""
+
+    on = KafkaRequiresEvents()  # pyright: ignore [reportGeneralTypeIssues]
+
+    def __init__(
+        self,
+        charm,
+        relation_name: str,
+        topic: str,
+        extra_user_roles: Optional[str] = None,
+        consumer_group_prefix: Optional[str] = None,
+    ):
+        """Manager of Kafka client relations."""
+        # super().__init__(charm, relation_name)
+        super().__init__(charm, relation_name, extra_user_roles)
+        self.charm = charm
+        self.topic = topic
+        self.consumer_group_prefix = consumer_group_prefix or ""
+
+    @property
+    def topic(self):
+        """Topic to use in Kafka."""
+        return self._topic
+
+    @topic.setter
+    def topic(self, value):
+        # Avoid wildcards
+        if value == "*":
+            raise ValueError(f"Error on topic '{value}', cannot be a wildcard.")
+        self._topic = value
+
+    def _on_relation_created_event(self, event: RelationCreatedEvent) -> None:
+        """Event emitted when the Kafka relation is created."""
+        # Sets topic, extra user roles, and "consumer-group-prefix" in the relation
+        relation_data = {
+            f: getattr(self, f.replace("-", "_"), "")
+            for f in ["consumer-group-prefix", "extra-user-roles", "topic"]
+        }
+
+        self._update_relation_data(event.relation.id, relation_data)
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the Kafka relation has changed."""
+        # Check which data has changed to emit customs events.
+        diff = self._diff(event)
+
+        # Check if the topic is created
+        # (the Kafka charm shared the credentials).
+        if "username" in diff.added and "password" in diff.added:
+            # Emit the default event (the one without an alias).
+            logger.info("topic created at %s", datetime.now())
+            getattr(self.on, "topic_created").emit(event.relation, app=event.app, unit=event.unit)
+
+            # To avoid unnecessary application restarts do not trigger
+            # “endpoints_changed“ event if “topic_created“ is triggered.
+            return
+
+        # Emit an endpoints (bootstrap-server) changed event if the Kafka endpoints
+        # added or changed this info in the relation databag.
+        if "endpoints" in diff.added or "endpoints" in diff.changed:
+            # Emit the default event (the one without an alias).
+            logger.info("endpoints changed on %s", datetime.now())
+            getattr(self.on, "bootstrap_server_changed").emit(
+                event.relation, app=event.app, unit=event.unit
+            )  # here check if this is the right design
+            return
+
+
+# Opensearch related events
+
+
+class OpenSearchProvidesEvent(RelationEvent):
+    """Base class for OpenSearch events."""
+
+    @property
+    def index(self) -> Optional[str]:
+        """Returns the index that was requested."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("index")
+
+
+class IndexRequestedEvent(OpenSearchProvidesEvent, ExtraRoleEvent):
+    """Event emitted when a new index is requested for use on this relation."""
+
+
+class OpenSearchProvidesEvents(CharmEvents):
+    """OpenSearch events.
+
+    This class defines the events that OpenSearch can emit.
+    """
+
+    index_requested = EventSource(IndexRequestedEvent)
+
+
+class OpenSearchRequiresEvent(DatabaseRequiresEvent):
+    """Base class for OpenSearch requirer events."""
+
+
+class IndexCreatedEvent(AuthenticationEvent, OpenSearchRequiresEvent):
+    """Event emitted when a new index is created for use on this relation."""
+
+
+class OpenSearchRequiresEvents(CharmEvents):
+    """OpenSearch events.
+
+    This class defines the events that the opensearch requirer can emit.
+    """
+
+    index_created = EventSource(IndexCreatedEvent)
+    endpoints_changed = EventSource(DatabaseEndpointsChangedEvent)
+    authentication_updated = EventSource(AuthenticationEvent)
+
+
+# OpenSearch Provides and Requires Objects
+
+
+class OpenSearchProvides(DataProvides):
+    """Provider-side of the OpenSearch relation."""
+
+    on = OpenSearchProvidesEvents()  # pyright: ignore[reportGeneralTypeIssues]
+
+    def __init__(self, charm: CharmBase, relation_name: str) -> None:
+        super().__init__(charm, relation_name)
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the relation has changed."""
+        # Only the leader should handle this event.
+        if not self.local_unit.is_leader():
+            return
+
+        # Check which data has changed to emit customs events.
+        diff = self._diff(event)
+
+        # Emit an index requested event if the setup key (index name and optional extra user roles)
+        # have been added to the relation databag by the application.
+        if "index" in diff.added:
+            getattr(self.on, "index_requested").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+    def set_index(self, relation_id: int, index: str) -> None:
+        """Set the index in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            index: the index as it is _created_ on the provider charm. This needn't match the
+                requested index, and can be used to present a different index name if, for example,
+                the requested index is invalid.
+        """
+        self._update_relation_data(relation_id, {"index": index})
+
+    def set_endpoints(self, relation_id: int, endpoints: str) -> None:
+        """Set the endpoints in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            endpoints: the endpoint addresses for opensearch nodes.
+        """
+        self._update_relation_data(relation_id, {"endpoints": endpoints})
+
+    def set_version(self, relation_id: int, version: str) -> None:
+        """Set the opensearch version in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            version: database version.
+        """
+        self._update_relation_data(relation_id, {"version": version})
+
+
+class OpenSearchRequires(DataRequires):
+    """Requires-side of the OpenSearch relation."""
+
+    on = OpenSearchRequiresEvents()  # pyright: ignore[reportGeneralTypeIssues]
+
+    def __init__(
+        self, charm, relation_name: str, index: str, extra_user_roles: Optional[str] = None
+    ):
+        """Manager of OpenSearch client relations."""
+        super().__init__(charm, relation_name, extra_user_roles)
+        self.charm = charm
+        self.index = index
+
+    def _on_relation_created_event(self, event: RelationCreatedEvent) -> None:
+        """Event emitted when the OpenSearch relation is created."""
+        # Sets both index and extra user roles in the relation if the roles are provided.
+        # Otherwise, sets only the index.
+        data = {"index": self.index}
+        if self.extra_user_roles:
+            data["extra-user-roles"] = self.extra_user_roles
+
+        self._update_relation_data(event.relation.id, data)
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the OpenSearch relation has changed.
+
+        This event triggers individual custom events depending on the changing relation.
+        """
+        # Check which data has changed to emit customs events.
+        diff = self._diff(event)
+
+        # Check if authentication has updated, emit event if so
+        updates = {"username", "password", "tls", "tls-ca"}
+        if len(set(diff._asdict().keys()) - updates) < len(diff):
+            logger.info("authentication updated at: %s", datetime.now())
+            getattr(self.on, "authentication_updated").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+        # Check if the index is created
+        # (the OpenSearch charm shares the credentials).
+        if "username" in diff.added and "password" in diff.added:
+            # Emit the default event (the one without an alias).
+            logger.info("index created at: %s", datetime.now())
+            getattr(self.on, "index_created").emit(event.relation, app=event.app, unit=event.unit)
+
+            # To avoid unnecessary application restarts do not trigger
+            # “endpoints_changed“ event if “index_created“ is triggered.
+            return
+
+        # Emit a endpoints changed event if the OpenSearch application added or changed this info
+        # in the relation databag.
+        if "endpoints" in diff.added or "endpoints" in diff.changed:
+            # Emit the default event (the one without an alias).
+            logger.info("endpoints changed on %s", datetime.now())
+            getattr(self.on, "endpoints_changed").emit(
+                event.relation, app=event.app, unit=event.unit
+            )  # here check if this is the right design
+            return

--- a/tests/integration/database-charm/actions.yaml
+++ b/tests/integration/database-charm/actions.yaml
@@ -6,21 +6,55 @@ change-admin-password:
 set-secret:
   description: Change the value of a particular secret
   params:
+    relation_id:
+      type: integer 
+      description: The relation's unique ID
     field:
       type: string
       description: The mapping name, i.e. what databag field ('secret-<mapping>') is to be changed
 
+get-relation-field:
+  description: Set fields from the relation
+  params:
+    relation_id:
+      type: integer 
+      description: The relation's unique ID
+    field:
+      type: string
+      description: Relation field
+
+get-relation-self-side-field:
+  description: Set fields from the relation
+  params:
+    relation_id:
+      type: integer 
+      description: The relation's unique ID
+    field:
+      type: string
+      description: Relation field
+
 set-relation-field:
   description: Set fields from the relation
-  field:
-    type: string
-    description: Relation field
-  value:
-    type: string
-    description: Value of the field to set
+  params:
+    relation_id:
+      type: integer 
+      description: The relation's unique ID
+    field:
+      type: string
+      description: Relation field
+    value:
+      type: string
+      description: Value of the field to set
 
 delete-relation-field:
   description: Delete fields from the relation
-  field:
-    type: string
-    description: Relation field
+  params:
+    relation_id:
+      type: integer 
+      description: The relation's unique ID
+    relation_id:
+      type: integer
+      description: The relation's unique ID
+    field:
+      type: string
+      description: Relation field

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -534,7 +534,7 @@ async def test_provider_deleted_secret_is_removed(ops_test: OpsTest):
 
 async def test_requires_get_set_delete_fields(ops_test: OpsTest):
     # Add normal field
-    leader_id = await get_leader_id(ops_test, DATABASE_APP_NAME)
+    leader_id = await get_leader_id(ops_test, APPLICATION_APP_NAME)
     leader_name = f"{APPLICATION_APP_NAME}/{leader_id}"
 
     action = await ops_test.model.units.get(leader_name).run_action(

--- a/tests/integration/test_rolling_upgrade.py
+++ b/tests/integration/test_rolling_upgrade.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 import asyncio
 import logging
@@ -28,12 +28,11 @@ SECOND_DATABASE_RELATION_NAME = "second-database"
 SECRET_REF_PREFIX = "secret-"
 
 
-# Global variables to store the relation ID after creation
-# def pytest_namespace():
-#     return {"first_database_relation": None, "second_database_relation": None}
-
-
 async def downgrade_to_databag(ops_test, app_name):
+    """Helper function simulating a "rolling downgrade".
+
+    The data_interfaces module is replaced "on-the-fly" by an older version, where Juju Secrets aren't enabled yet.
+    """
     for unit in ops_test.model.applications[app_name].units:
         unit_name_with_dash = unit.name.replace("/", "-")
         complete_command = (
@@ -44,6 +43,10 @@ async def downgrade_to_databag(ops_test, app_name):
 
 
 async def upgrade_to_secrets(ops_test, app_name):
+    """Helper function simulating a "rolling upgrade".
+
+    The data_interfaces module is replaced "on-the-fly" by the latest version, using Juju secrets.
+    """
     for unit in ops_test.model.applications[app_name].units:
         unit_name_with_dash = unit.name.replace("/", "-")
         complete_command = (

--- a/tests/integration/test_rolling_upgrade.py
+++ b/tests/integration/test_rolling_upgrade.py
@@ -1,0 +1,552 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+import asyncio
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+from pytest_operator.plugin import OpsTest
+
+from .helpers import (
+    get_application_relation_data,
+    get_leader_id,
+)
+
+logger = logging.getLogger(__name__)
+
+APPLICATION_APP_NAME = "application"
+DATABASE_APP_NAME = "database"
+APP_NAMES = [APPLICATION_APP_NAME, DATABASE_APP_NAME]
+DATABASE_APP_METADATA = yaml.safe_load(
+    Path("./tests/integration/database-charm/metadata.yaml").read_text()
+)
+FIRST_DATABASE_RELATION_NAME = "first-database"
+SECOND_DATABASE_RELATION_NAME = "second-database"
+
+SECRET_REF_PREFIX = "secret-"
+
+
+# Global variables to store the relation ID after creation
+# def pytest_namespace():
+#     return {"first_database_relation": None, "second_database_relation": None}
+
+
+async def downgrade_to_databag(ops_test, app_name):
+    for unit in ops_test.model.applications[app_name].units:
+        unit_name_with_dash = unit.name.replace("/", "-")
+        complete_command = (
+            "scp tests/integration/data/data_interfaces.py "
+            f"{unit.name}:/var/lib/juju/agents/unit-{unit_name_with_dash}/charm/lib/charms/data_platform_libs/v0/"
+        )
+        x, stdout, y = await ops_test.juju(*complete_command.split())
+
+
+async def upgrade_to_secrets(ops_test, app_name):
+    for unit in ops_test.model.applications[app_name].units:
+        unit_name_with_dash = unit.name.replace("/", "-")
+        complete_command = (
+            "scp lib/charms/data_platform_libs/v0/data_interfaces.py "
+            f"{unit.name}:/var/lib/juju/agents/unit-{unit_name_with_dash}/charm/lib/charms/data_platform_libs/v0/"
+        )
+        x, stdout, y = await ops_test.juju(*complete_command.split())
+
+
+@pytest.mark.abort_on_fail
+async def test_deploy_charms(ops_test: OpsTest, application_charm, database_charm):
+    """Deploy both charms (application and database) to use in the tests."""
+    await asyncio.gather(
+        ops_test.model.deploy(
+            application_charm, application_name=APPLICATION_APP_NAME, num_units=1, series="jammy"
+        ),
+        ops_test.model.deploy(
+            database_charm,
+            resources={
+                "database-image": DATABASE_APP_METADATA["resources"]["database-image"][
+                    "upstream-source"
+                ]
+            },
+            application_name=DATABASE_APP_NAME,
+            num_units=1,
+            series="jammy",
+        ),
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[APPLICATION_APP_NAME, DATABASE_APP_NAME], status="active", wait_for_exact_units=1
+    )
+
+
+#
+# NOTE: Tests below have follow a strict sequence.
+# Pls only insert among if strongly justified.
+#
+
+# -----------------------------------------------------
+# Testing 'Requires - databag' vs. 'Provides - secrets'
+# -----------------------------------------------------
+
+
+@pytest.mark.abort_on_fail
+async def test_unbalanced_versions_falling_back_to_databag_req_databag_vs_prov_secrets(
+    ops_test: OpsTest,
+):
+    """Relating Requires (databag only) with Provides (that could use secrets).
+
+    This should fall back to databag usage.
+    """
+    await downgrade_to_databag(ops_test, APPLICATION_APP_NAME)
+
+    # Storing Relation object in 'pytest' global namespace for the session
+    pytest.first_database_relation = await ops_test.model.add_relation(
+        f"{APPLICATION_APP_NAME}:{FIRST_DATABASE_RELATION_NAME}", DATABASE_APP_NAME
+    )
+    await ops_test.model.wait_for_idle(apps=APP_NAMES, status="active")
+
+    # Secrest are correctly set in databag
+    username = await get_application_relation_data(
+        ops_test, APPLICATION_APP_NAME, FIRST_DATABASE_RELATION_NAME, "username"
+    )
+    password = await get_application_relation_data(
+        ops_test, APPLICATION_APP_NAME, FIRST_DATABASE_RELATION_NAME, "password"
+    )
+
+    assert username
+    assert password
+
+    assert (
+        await get_application_relation_data(
+            ops_test, APPLICATION_APP_NAME, FIRST_DATABASE_RELATION_NAME, "secret-user"
+        )
+        is None
+    )
+
+    # Interface functions (invoked by actions below) are consistent
+    leader_id = await get_leader_id(ops_test, DATABASE_APP_NAME)
+    leader_name = f"{DATABASE_APP_NAME}/{leader_id}"
+    action = await ops_test.model.units.get(leader_name).run_action(
+        "get-relation-self-side-field",
+        **{"relation_id": pytest.first_database_relation.id, "field": "username"},
+    )
+    await action.wait()
+    assert action.results.get("value") == username
+
+    leader_id = await get_leader_id(ops_test, DATABASE_APP_NAME)
+    leader_name = f"{DATABASE_APP_NAME}/{leader_id}"
+    action = await ops_test.model.units.get(leader_name).run_action(
+        "get-relation-self-side-field",
+        **{"relation_id": pytest.first_database_relation.id, "field": "password"},
+    )
+    await action.wait()
+    assert action.results.get("value") == password
+
+
+@pytest.mark.abort_on_fail
+async def test_transparent_upgrade_requires_databag_vs_provides_secrets(ops_test: OpsTest):
+    """Upgrading Requires to use secrets (if possible).
+
+    YET, already existing relations keep using the databag for all operations (fetch, update, delete)
+    """
+    await upgrade_to_secrets(ops_test, APPLICATION_APP_NAME)
+
+    # Application charm leader
+    leader_app_id = await get_leader_id(ops_test, DATABASE_APP_NAME)
+    leader_app_name = f"{APPLICATION_APP_NAME}/{leader_app_id}"
+
+    # DB leader
+    leader_id = await get_leader_id(ops_test, DATABASE_APP_NAME)
+    leader_name = f"{DATABASE_APP_NAME}/{leader_id}"
+
+    # Set new sensitive information (if secrets: stored in 'secret-user')
+    uris_new_val = "http://username:password@example.com"
+    action = await ops_test.model.units.get(leader_name).run_action(
+        "set-relation-field",
+        **{
+            "relation_id": pytest.first_database_relation.id,
+            "field": "uris",
+            "value": uris_new_val,
+        },
+    )
+    await action.wait()
+
+    # Relation data is correct
+    assert uris_new_val == await get_application_relation_data(
+        ops_test, APPLICATION_APP_NAME, FIRST_DATABASE_RELATION_NAME, "uris"
+    )
+    assert (
+        await get_application_relation_data(
+            ops_test, APPLICATION_APP_NAME, FIRST_DATABASE_RELATION_NAME, "secret-user"
+        )
+        is None
+    )
+
+    # Interface functions (invoked by actions below) are consistent
+    action = await ops_test.model.units.get(leader_app_name).run_action(
+        "get-relation-field",
+        **{"relation_id": pytest.first_database_relation.id, "field": "uris"},
+    )
+    await action.wait()
+    assert action.results.get("value") == uris_new_val
+
+    action = await ops_test.model.units.get(leader_name).run_action(
+        "get-relation-self-side-field",
+        **{"relation_id": pytest.first_database_relation.id, "field": "uris"},
+    )
+    await action.wait()
+    assert action.results.get("value") == uris_new_val
+
+    action = await ops_test.model.units.get(leader_name).run_action(
+        "delete-relation-field",
+        **{"relation_id": pytest.first_database_relation.id, "field": "uris"},
+    )
+    await action.wait()
+
+    # Relation data is correct
+    assert (
+        await get_application_relation_data(
+            ops_test, APPLICATION_APP_NAME, FIRST_DATABASE_RELATION_NAME, "uris"
+        )
+        is None
+    )
+
+    assert (
+        await get_application_relation_data(
+            ops_test, APPLICATION_APP_NAME, FIRST_DATABASE_RELATION_NAME, "secret-user"
+        )
+        is None
+    )
+
+    # Interface functions (invoked by actions below) are consistent
+    action = await ops_test.model.units.get(leader_name).run_action(
+        "get-relation-self-side-field",
+        **{"relation_id": pytest.first_database_relation.id, "field": "uris"},
+    )
+    await action.wait()
+    assert not action.results.get("value")
+
+
+@pytest.mark.abort_on_fail
+async def test_transparent_upgrade_requires_databag_vs_provides_secrets_upgrade_new_secret(
+    ops_test: OpsTest,
+):
+    """After Requires upgrade, we stay on the databag."""
+    # Application charm leader
+    leader_app_id = await get_leader_id(ops_test, DATABASE_APP_NAME)
+    leader_app_name = f"{APPLICATION_APP_NAME}/{leader_app_id}"
+
+    # DB leader
+    leader_id = await get_leader_id(ops_test, DATABASE_APP_NAME)
+    leader_name = f"{DATABASE_APP_NAME}/{leader_id}"
+
+    # Set new sensitive information (if secrets: stored in 'secret-tls')
+    tls_ca_val = "<ca_cert_here>"
+    action = await ops_test.model.units.get(leader_name).run_action(
+        "set-relation-field",
+        **{
+            "relation_id": pytest.first_database_relation.id,
+            "field": "tls-ca",
+            "value": tls_ca_val,
+        },
+    )
+    await action.wait()
+
+    # We stay on the databag
+    assert await get_application_relation_data(
+        ops_test, APPLICATION_APP_NAME, FIRST_DATABASE_RELATION_NAME, "tls-ca"
+    )
+
+    assert (
+        await get_application_relation_data(
+            ops_test, APPLICATION_APP_NAME, FIRST_DATABASE_RELATION_NAME, "secret-tls"
+        )
+        is None
+    )
+
+    # Interface functions (invoked by actions below) are consistent
+    action = await ops_test.model.units.get(leader_app_name).run_action(
+        "get-relation-field",
+        **{"relation_id": pytest.first_database_relation.id, "field": "tls-ca"},
+    )
+    await action.wait()
+    assert action.results.get("value") == tls_ca_val
+
+    action = await ops_test.model.units.get(leader_name).run_action(
+        "get-relation-self-side-field",
+        **{"relation_id": pytest.first_database_relation.id, "field": "tls-ca"},
+    )
+    await action.wait()
+    assert action.results.get("value") == tls_ca_val
+
+    action = await ops_test.model.units.get(leader_name).run_action(
+        "delete-relation-field",
+        **{"relation_id": pytest.first_database_relation.id, "field": "tls-ca"},
+    )
+    await action.wait()
+
+    action = await ops_test.model.units.get(leader_app_name).run_action(
+        "get-relation-field",
+        **{"relation_id": pytest.first_database_relation.id, "field": "tls-ca"},
+    )
+    await action.wait()
+    assert not action.results.get("value")
+
+    # Previously existing sensitive data stays where it was
+    password = await get_application_relation_data(
+        ops_test, APPLICATION_APP_NAME, FIRST_DATABASE_RELATION_NAME, "password"
+    )
+    assert password
+
+    assert (
+        await get_application_relation_data(
+            ops_test, APPLICATION_APP_NAME, FIRST_DATABASE_RELATION_NAME, "secret-user"
+        )
+        is None
+    )
+
+    action = await ops_test.model.units.get(leader_app_name).run_action(
+        "get-relation-field",
+        **{"relation_id": pytest.first_database_relation.id, "field": "password"},
+    )
+    await action.wait()
+    assert action.results.get("value") == password
+
+    action = await ops_test.model.units.get(leader_name).run_action(
+        "get-relation-self-side-field",
+        **{"relation_id": pytest.first_database_relation.id, "field": "password"},
+    )
+    await action.wait()
+    assert action.results.get("value") == password
+
+
+# -----------------------------------------------------
+# Testing 'Requires - secrets' vs. 'Provides - databag'
+# -----------------------------------------------------
+
+
+@pytest.mark.abort_on_fail
+async def test_unbalanced_versions_falling_back_to_databag_req_secrets_vs_prov_databag(
+    ops_test: OpsTest,
+):
+    """Relating Requires (secrets available) with Provides (databag only).
+
+    This should fall back to databag usage.
+    """
+    await downgrade_to_databag(ops_test, DATABASE_APP_NAME)
+
+    # Storing Relation object in 'pytest' global namespace for the session
+    pytest.second_database_relation = await ops_test.model.add_relation(
+        f"{APPLICATION_APP_NAME}:{SECOND_DATABASE_RELATION_NAME}", DATABASE_APP_NAME
+    )
+    await ops_test.model.wait_for_idle(apps=APP_NAMES, status="active")
+
+    # Relation data is correct
+    username = await get_application_relation_data(
+        ops_test, APPLICATION_APP_NAME, SECOND_DATABASE_RELATION_NAME, "username"
+    )
+    password = await get_application_relation_data(
+        ops_test, APPLICATION_APP_NAME, SECOND_DATABASE_RELATION_NAME, "password"
+    )
+
+    assert (
+        await get_application_relation_data(
+            ops_test, APPLICATION_APP_NAME, SECOND_DATABASE_RELATION_NAME, "secret-user"
+        )
+        is None
+    )
+
+    # Interface functions (invoked by actions below) are consistent
+    leader_id = await get_leader_id(ops_test, DATABASE_APP_NAME)
+    leader_name = f"{DATABASE_APP_NAME}/{leader_id}"
+    action = await ops_test.model.units.get(leader_name).run_action(
+        "get-relation-self-side-field",
+        **{"relation_id": pytest.second_database_relation.id, "field": "username"},
+    )
+    await action.wait()
+    assert action.results.get("value") == username
+
+    leader_id = await get_leader_id(ops_test, DATABASE_APP_NAME)
+    leader_name = f"{DATABASE_APP_NAME}/{leader_id}"
+    action = await ops_test.model.units.get(leader_name).run_action(
+        "get-relation-self-side-field",
+        **{"relation_id": pytest.second_database_relation.id, "field": "password"},
+    )
+    await action.wait()
+    assert action.results.get("value") == password
+
+
+@pytest.mark.abort_on_fail
+async def test_transparent_upgrade_keeping_databag_requires_secrets_vs_provides_databag(
+    ops_test: OpsTest,
+):
+    """Upgrading Provides to use secrets (if possible).
+
+    YET, already existing relations keep using the databag for all operations (fetch, update, delete)
+    """
+    await upgrade_to_secrets(ops_test, DATABASE_APP_NAME)
+
+    # Application charm leader
+    leader_app_id = await get_leader_id(ops_test, DATABASE_APP_NAME)
+    leader_app_name = f"{APPLICATION_APP_NAME}/{leader_app_id}"
+
+    # DB leader
+    leader_id = await get_leader_id(ops_test, DATABASE_APP_NAME)
+    leader_name = f"{DATABASE_APP_NAME}/{leader_id}"
+
+    # Set new sensitive information (if secrets: stored in 'secret-user')
+    uris_new_val = "http://username:password@example.com"
+    action = await ops_test.model.units.get(leader_name).run_action(
+        "set-relation-field",
+        **{
+            "relation_id": pytest.second_database_relation.id,
+            "field": "uris",
+            "value": uris_new_val,
+        },
+    )
+    await action.wait()
+
+    # Relation data is correct
+    assert uris_new_val == await get_application_relation_data(
+        ops_test, APPLICATION_APP_NAME, SECOND_DATABASE_RELATION_NAME, "uris"
+    )
+    assert (
+        await get_application_relation_data(
+            ops_test, APPLICATION_APP_NAME, SECOND_DATABASE_RELATION_NAME, "secret-user"
+        )
+        is None
+    )
+
+    # Interface functions (invoked by actions below) are consistent
+    action = await ops_test.model.units.get(leader_app_name).run_action(
+        "get-relation-field",
+        **{"relation_id": pytest.second_database_relation.id, "field": "uris"},
+    )
+    await action.wait()
+    assert action.results.get("value") == uris_new_val
+
+    action = await ops_test.model.units.get(leader_name).run_action(
+        "get-relation-self-side-field",
+        **{"relation_id": pytest.second_database_relation.id, "field": "uris"},
+    )
+    await action.wait()
+    assert action.results.get("value") == uris_new_val
+
+    action = await ops_test.model.units.get(leader_name).run_action(
+        "delete-relation-field",
+        **{"relation_id": pytest.second_database_relation.id, "field": "uris"},
+    )
+    await action.wait()
+
+    # Relation data is correct
+    assert (
+        await get_application_relation_data(
+            ops_test, APPLICATION_APP_NAME, SECOND_DATABASE_RELATION_NAME, "uris"
+        )
+        is None
+    )
+
+    assert (
+        await get_application_relation_data(
+            ops_test, APPLICATION_APP_NAME, SECOND_DATABASE_RELATION_NAME, "secret-user"
+        )
+        is None
+    )
+
+    # Interface functions (invoked by actions below) are consistent
+    action = await ops_test.model.units.get(leader_name).run_action(
+        "get-relation-self-side-field",
+        **{"relation_id": pytest.second_database_relation.id, "field": "uris"},
+    )
+    await action.wait()
+    assert not action.results.get("value")
+
+
+@pytest.mark.abort_on_fail
+async def test_transparent_upgrade_keeping_databag_requires_secrets_vs_provides_databag_upgrade_new_secret(
+    ops_test: OpsTest,
+):
+    """After Provider upgrade, the relation remains on databag."""
+    # Application charm leader
+    leader_app_id = await get_leader_id(ops_test, DATABASE_APP_NAME)
+    leader_app_name = f"{APPLICATION_APP_NAME}/{leader_app_id}"
+
+    # DB leader
+    leader_id = await get_leader_id(ops_test, DATABASE_APP_NAME)
+    leader_name = f"{DATABASE_APP_NAME}/{leader_id}"
+
+    # Set new sensitive information (if secrets: stored in 'secret-tls')
+    tls_ca_val = "<ca_cert_here>"
+    action = await ops_test.model.units.get(leader_name).run_action(
+        "set-relation-field",
+        **{
+            "relation_id": pytest.second_database_relation.id,
+            "field": "tls-ca",
+            "value": tls_ca_val,
+        },
+    )
+    await action.wait()
+
+    tls_ca_val = await get_application_relation_data(
+        ops_test, APPLICATION_APP_NAME, SECOND_DATABASE_RELATION_NAME, "tls-ca"
+    )
+
+    assert (
+        await get_application_relation_data(
+            ops_test, APPLICATION_APP_NAME, SECOND_DATABASE_RELATION_NAME, "secret-tls"
+        )
+        is None
+    )
+
+    # Interface functions (invoked by actions below) are consistent
+    action = await ops_test.model.units.get(leader_app_name).run_action(
+        "get-relation-field",
+        **{"relation_id": pytest.second_database_relation.id, "field": "tls-ca"},
+    )
+    await action.wait()
+    assert action.results.get("value") == tls_ca_val
+
+    action = await ops_test.model.units.get(leader_name).run_action(
+        "get-relation-self-side-field",
+        **{"relation_id": pytest.second_database_relation.id, "field": "tls-ca"},
+    )
+    await action.wait()
+    assert action.results.get("value") == tls_ca_val
+
+    action = await ops_test.model.units.get(leader_name).run_action(
+        "delete-relation-field",
+        **{"relation_id": pytest.second_database_relation.id, "field": "tls-ca"},
+    )
+    await action.wait()
+
+    action = await ops_test.model.units.get(leader_app_name).run_action(
+        "get-relation-field",
+        **{"relation_id": pytest.second_database_relation.id, "field": "tls-ca"},
+    )
+    await action.wait()
+    assert not action.results.get("value")
+
+    # Previously existing sensitive data stays where it was
+    password = await get_application_relation_data(
+        ops_test, APPLICATION_APP_NAME, SECOND_DATABASE_RELATION_NAME, "password"
+    )
+    assert password
+
+    assert (
+        await get_application_relation_data(
+            ops_test, APPLICATION_APP_NAME, SECOND_DATABASE_RELATION_NAME, "secret-user"
+        )
+        is None
+    )
+
+    action = await ops_test.model.units.get(leader_app_name).run_action(
+        "get-relation-field",
+        **{"relation_id": pytest.second_database_relation.id, "field": "password"},
+    )
+    await action.wait()
+    assert action.results.get("value") == password
+
+    action = await ops_test.model.units.get(leader_name).run_action(
+        "get-relation-self-side-field",
+        **{"relation_id": pytest.second_database_relation.id, "field": "password"},
+    )
+    await action.wait()
+    assert action.results.get("value") == password

--- a/tox.ini
+++ b/tox.ini
@@ -86,6 +86,18 @@ deps =
 commands =
     pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/test_charm.py
 
+[testenv:integration-upgrades]
+description = Run database integration tests
+deps =
+    psycopg2-binary
+    pytest
+    juju{env:LIBJUJU_VERSION_SPECIFIER:==2.9.42.4}
+    pytest-operator
+    pytest-mock
+    -r {tox_root}/requirements.txt
+commands =
+    pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/test_rolling_upgrade.py
+
 [testenv:integration-kafka]
 description = Run Kafka integration tests
 deps =


### PR DESCRIPTION
A major bug was discovered. When using secrets, all secret info was also duplicated into the databag.

## Details:

On [line 783](https://github.com/canonical/data-platform-libs/blob/main/lib/charms/data_platform_libs/v0/data_interfaces.py#L783) the `second_chance_as_normal_field` variable was always true. (Should have been set `False` in modification functions, by mistake.)

However since in parallel we had concerns regarding rolling upgrades, I provided a fix that also addresses the rolling upgrades issue.

During development [another bug](https://github.com/canonical/data-platform-libs/issues/108) was discovered. To be fixed in a separate PR. Tests `xfail`-ing until.