### PR TITLE
[DPE-3054] PeerRelation withing the same guidelines as Requires and Provides

### DIFF
--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -874,9 +874,6 @@ class DataRelation(Object, ABC):
         if app not in relation.data or relation.data[app] is None:
             return
 
-        if any(self._is_secret_field(key) for key in data.keys()):
-            raise SecretsIllegalUpdateError("Can't update secret {key}.")
-
         if relation:
             relation.data[app].update(data)
 

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -320,7 +320,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 24
+LIBPATCH = 25
 
 PYDEPS = ["ops>=2.0.0"]
 

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -889,7 +889,7 @@ class DataRelation(Object, ABC):
                 relation.data[app].pop(field)
             except KeyError:
                 logger.error(
-                    "Non-existing secret '%s' was attempted to be removed from the databag (relation ID: %s)",
+                    "Non-existing field '%s' was attempted to be removed from the databag (relation ID: %s)",
                     str(field),
                     str(relation.id),
                 )
@@ -1617,6 +1617,27 @@ class DataPeer(DataRequires, DataProvides):
                 relation, self.secret_fields, fields, self._delete_relation_secret, fields=fields
             )
         self._delete_relation_data_without_secrets(self.component, relation, list(normal_fields))
+
+    def fetch_relation_data(
+        self,
+        relation_ids: Optional[List[int]] = None,
+        fields: Optional[List[str]] = None,
+        relation_name: Optional[str] = None,
+    ) -> Dict[int, Dict[str, str]]:
+        """This method makes no sense for a Peer Relation."""
+        raise NotImplementedError(
+            "Peer Relation only supports 'self-side' fetch methods: "
+            "fetch_my_relation_data() and fetch_my_relation_field()"
+        )
+
+    def fetch_relation_field(
+        self, relation_id: int, field: str, relation_name: Optional[str] = None
+    ) -> Optional[str]:
+        """This method makes no sense for a Peer Relation."""
+        raise NotImplementedError(
+            "Peer Relation only supports 'self-side' fetch methods: "
+            "fetch_my_relation_data() and fetch_my_relation_field()"
+        )
 
     # Public functions -- inherited
 

--- a/tests/integration/database-charm/actions.yaml
+++ b/tests/integration/database-charm/actions.yaml
@@ -50,11 +50,41 @@ delete-relation-field:
   description: Delete fields from the relation
   params:
     relation_id:
-      type: integer 
-      description: The relation's unique ID
-    relation_id:
       type: integer
       description: The relation's unique ID
+    field:
+      type: string
+      description: Relation field
+
+get-peer-relation-field:
+  description: Get fields from the second-database relation
+  params:
+    component:
+      type: string
+      description: app/unit
+    field:
+      type: string
+      description: Relation field
+
+set-peer-relation-field:
+  description: Set fields from the second-database relation
+  params:
+    component:
+      type: string
+      description: app/unit
+    field:
+      type: string
+      description: Relation field
+    value:
+      type: string
+      description: Value of the field to set
+
+delete-peer-relation-field:
+  description: Delete fields from the sedond-database relation
+  params:
+    component:
+      type: string
+      description: app/unit
     field:
       type: string
       description: Relation field

--- a/tests/integration/database-charm/metadata.yaml
+++ b/tests/integration/database-charm/metadata.yaml
@@ -20,6 +20,10 @@ resources:
     description: OCI image for database
     upstream-source: ubuntu/postgres@sha256:f0b7dcc3088c018ebcd90dd8b4e9007b094fd180d5a12f5be3e7120914ac159d
 
+peers:
+  database-peers:
+    interface: database-peers
+
 provides:
   database:
     interface: database_client

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -356,6 +356,9 @@ async def test_provider_with_additional_secrets(ops_test: OpsTest, database_char
     assert topsecret1 != topsecret2
 
 
+@pytest.mark.log_errors_allowed(
+    "Non-existing secret 'doesnt_exist' was attempted to be removed from the databag"
+)
 @pytest.mark.parametrize("field,value", [("new_field", "blah"), ("tls", "True")])
 @pytest.mark.usefixtures("only_without_juju_secrets")
 async def test_provider_get_set_delete_fields(field, value, ops_test: OpsTest):
@@ -428,6 +431,9 @@ async def test_provider_get_set_delete_fields(field, value, ops_test: OpsTest):
     assert int(action.results["Code"]) == 0
 
 
+@pytest.mark.log_errors_allowed(
+    "Non-existing secret 'doesnt_exist' was attempted to be removed from the databag"
+)
 @pytest.mark.parametrize(
     "field,value,relation_field",
     [
@@ -514,6 +520,9 @@ async def test_provider_get_set_delete_fields_secrets(
     assert action.results["return-code"] == 0
 
 
+@pytest.mark.log_errors_allowed(
+    "Non-existing secret 'tls' was attempted to be removed from the databag"
+)
 @pytest.mark.log_errors_allowed("Can't delete secret for relation")
 @pytest.mark.usefixtures("only_with_juju_secrets")
 async def test_provider_deleted_secret_is_removed(ops_test: OpsTest):

--- a/tests/unit/test_data_interfaces.py
+++ b/tests/unit/test_data_interfaces.py
@@ -332,7 +332,7 @@ class TestDatabaseProvides(DataProvidesBaseTests, unittest.TestCase):
         }
 
         secret = self.harness.charm.model.get_secret(id=secret_id)
-        assert secret.get_content() == {
+        assert secret.peek_content() == {
             "tls": "True",
             "tls-ca": "Canonical",
         }
@@ -661,7 +661,7 @@ class TestKafkaProvides(DataProvidesBaseTests, unittest.TestCase):
         }
 
         secret = self.harness.charm.model.get_secret(id=secret_id)
-        assert secret.get_content() == {
+        assert secret.peek_content() == {
             "tls": "True",
             "tls-ca": "Canonical",
         }

--- a/tests/unit/test_data_interfaces.py
+++ b/tests/unit/test_data_interfaces.py
@@ -26,6 +26,8 @@ from charms.data_platform_libs.v0.data_interfaces import (
     DatabaseRequestedEvent,
     DatabaseRequires,
     DatabaseRequiresEvents,
+    DataPeer,
+    DataPeerUnit,
     Diff,
     IndexRequestedEvent,
     KafkaProvides,
@@ -38,12 +40,19 @@ from charms.harness_extensions.v0.capture_events import capture, capture_events
 
 logger = getLogger(__name__)
 
+PEER_RELATION_NAME = "database-peers"
+
 DATABASE = "data_platform"
 EXTRA_USER_ROLES = "CREATEDB,CREATEROLE"
 DATABASE_RELATION_INTERFACE = "database_client"
 DATABASE_RELATION_NAME = "database"
 DATABASE_METADATA = f"""
 name: database
+
+peers:
+  database-peers:
+    interface: database-peers
+
 provides:
   {DATABASE_RELATION_NAME}:
     interface: {DATABASE_RELATION_INTERFACE}
@@ -76,6 +85,8 @@ class DatabaseCharm(CharmBase):
 
     def __init__(self, *args):
         super().__init__(*args)
+        self.peer_relation_app = DataPeer(self, PEER_RELATION_NAME)
+        self.peer_relation_app = DataPeerUnit(self, PEER_RELATION_NAME)
         self.provider = DatabaseProvides(
             self,
             DATABASE_RELATION_NAME,
@@ -561,6 +572,14 @@ class TestDatabaseProvides(DataProvidesBaseTests, unittest.TestCase):
         with capture(self.harness.charm, DatabaseRequestedEvent) as captured:
             self.harness.update_relation_data(self.rel_id, "application/0", {"database": DATABASE})
         assert captured.event.unit.name == "application/0"
+
+    def test_peer_relation_disabled_functions(self):
+        """Verify that fetch_relation_data/field() functions are disabled for Peer Relations."""
+        with pytest.raises(NotImplementedError):
+            self.harness.charm.peer_relation_app.fetch_relation_data(0, ["key"])
+
+        with pytest.raises(NotImplementedError):
+            self.harness.charm.peer_relation_app.fetch_relation_field(0, "key")
 
 
 class TestKafkaProvides(DataProvidesBaseTests, unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -17,11 +17,13 @@ set_env =
     PYTHONPATH = {tox_root}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=ipdb.set_trace
     PY_COLORS=1
+    PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
 pass_env =
     PYTHONPATH
     CHARM_BUILD_DIR
     MODEL_SETTINGS
     LIBJUJU_VERSION_SPECIFIER
+    PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
 
 [testenv:format]
 description = Apply coding style standards to code


### PR DESCRIPTION
Implementing Peer Relations data abstraction and data interaction as the exact same like what we have for Cross-charm relations.

The proposal is FULLY re-using already existing code (behavior) set for Cross-charm Relations.

There are 3 Peer-specific requirements (how it's been implemented in the charms) that are taken over here:

Rolling upgrades
 1. If only databag was used (i.e. Internal Secrets in plain text) -> We move secrets one-by-one to a Juju Secret whenever the secret field is referred to
 2. If the charm was already using secrets BUT not by labels but URI ->  We remove the URI from the databag and stick a label on the secret
 
 Protection against old bugs (i.e. versions compatibilty):
 
 3. "deleted label": Soft delete, i.e. if a secret is to be removed, we just replace the value with a specific label