### PR TITLE
fix: add missing dependency (pylibjuju)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+juju ~= 3.1
 ops >= 2.1.1
 pydantic>=1.10,<2
 poetry-core


### PR DESCRIPTION
The tests use importlib.metadata to get the installed version of pylibjuju:

```python

However, pylibjuju is not installed as part of the requirements. This means that all tests fail with an error like:

```
ERROR tests/unit/test_data_interfaces.py::TestDatabaseProvides::test_database_requested_event - importlib.metadata.PackageNotFoundError: No package metadata was found for juju
```

