### PR TITLE
fix: handle changed Juju secret owner content behaviour

### DIFF
--- a/lib/charms/data_platform_libs/v0/data_secrets.py
+++ b/lib/charms/data_platform_libs/v0/data_secrets.py
@@ -97,7 +97,7 @@ class CachedSecret:
         """Getting cached secret content."""
         if not self._secret_content:
             if self.meta:
-                self._secret_content = self.meta.get_content()
+                self._secret_content = self.meta.peek_content()
         return self._secret_content
 
     def set_content(self, content: Dict[str, str]) -> None:


### PR DESCRIPTION
As of [Juju 3.1.7](https://bugs.launchpad.net/juju/+bug/2037120) (and 3.3.1, and all versions from 3.4.0 onwards) the behaviour of accessing secret content in Juju has changed:

* In Juju <= 3.1.6 the secret owner would always refresh when getting the secret content, and they cannot explicitly do a refresh
* In Juju >=3.1.7 the secret owner has the same behaviour as all other secret users: they get the tracked revision unless they use peek or refresh (and they can use refresh now)

This change breaks the `data_secrets` library, because it gets the secret content (e.g. to add a new key:value) and that will now be the current revision, so will not have any local changes. In practice, this means that `data_secrets` can no longer add multiple secrets because when the second one is added, it's added to the revision that didn't have the first one.

The secret owner is able to use `peek` in both 3.1.6 and 3.1.7, so the safe change is to always use peek - this is required in 3.1.7, and has no effect in 3.1.6.