### PR TITLE
[DPE-3294] Add mongos requires

### DIFF
--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -422,15 +422,15 @@ def diff(event: RelationChangedEvent, bucket: Union[Unit, Application]) -> Diff:
     )
 
     # These are the keys that were added to the databag and triggered this event.
-    added = new_data.keys() - old_data.keys()  # pyright: ignore [reportGeneralTypeIssues]
+    added = new_data.keys() - old_data.keys()  # pyright: ignore [reportAssignmentType]
     # These are the keys that were removed from the databag and triggered this event.
-    deleted = old_data.keys() - new_data.keys()  # pyright: ignore [reportGeneralTypeIssues]
+    deleted = old_data.keys() - new_data.keys()  # pyright: ignore [reportAssignmentType]
     # These are the keys that already existed in the databag,
     # but had their values changed.
     changed = {
         key
-        for key in old_data.keys() & new_data.keys()  # pyright: ignore [reportGeneralTypeIssues]
-        if old_data[key] != new_data[key]  # pyright: ignore [reportGeneralTypeIssues]
+        for key in old_data.keys() & new_data.keys()  # pyright: ignore [reportAssignmentType]
+        if old_data[key] != new_data[key]  # pyright: ignore [reportAssignmentType]
     }
     # Convert the new_data to a serializable format and save it for a next diff check.
     set_encoded_field(event.relation, bucket, "data", new_data)
@@ -1909,7 +1909,7 @@ class DatabaseRequiresEvents(CharmEvents):
 class DatabaseProvides(DataProvides):
     """Provider-side of the database relations."""
 
-    on = DatabaseProvidesEvents()  # pyright: ignore [reportGeneralTypeIssues]
+    on = DatabaseProvidesEvents()  # pyright: ignore [reportAssignmentType]
 
     def __init__(self, charm: CharmBase, relation_name: str) -> None:
         super().__init__(charm, relation_name)
@@ -2004,7 +2004,7 @@ class DatabaseProvides(DataProvides):
 class DatabaseRequires(DataRequires):
     """Requires-side of the database relation."""
 
-    on = DatabaseRequiresEvents()  # pyright: ignore [reportGeneralTypeIssues]
+    on = DatabaseRequiresEvents()  # pyright: ignore [reportAssignmentType]
 
     def __init__(
         self,
@@ -2333,7 +2333,7 @@ class KafkaRequiresEvents(CharmEvents):
 class KafkaProvides(DataProvides):
     """Provider-side of the Kafka relation."""
 
-    on = KafkaProvidesEvents()  # pyright: ignore [reportGeneralTypeIssues]
+    on = KafkaProvidesEvents()  # pyright: ignore [reportAssignmentType]
 
     def __init__(self, charm: CharmBase, relation_name: str) -> None:
         super().__init__(charm, relation_name)
@@ -2394,7 +2394,7 @@ class KafkaProvides(DataProvides):
 class KafkaRequires(DataRequires):
     """Requires-side of the Kafka relation."""
 
-    on = KafkaRequiresEvents()  # pyright: ignore [reportGeneralTypeIssues]
+    on = KafkaRequiresEvents()  # pyright: ignore [reportAssignmentType]
 
     def __init__(
         self,
@@ -2531,7 +2531,7 @@ class OpenSearchRequiresEvents(CharmEvents):
 class OpenSearchProvides(DataProvides):
     """Provider-side of the OpenSearch relation."""
 
-    on = OpenSearchProvidesEvents()  # pyright: ignore[reportGeneralTypeIssues]
+    on = OpenSearchProvidesEvents()  # pyright: ignore[reportAssignmentType]
 
     def __init__(self, charm: CharmBase, relation_name: str) -> None:
         super().__init__(charm, relation_name)
@@ -2584,7 +2584,7 @@ class OpenSearchProvides(DataProvides):
 class OpenSearchRequires(DataRequires):
     """Requires-side of the OpenSearch relation."""
 
-    on = OpenSearchRequiresEvents()  # pyright: ignore[reportGeneralTypeIssues]
+    on = OpenSearchRequiresEvents()  # pyright: ignore[reportAssignmentType]
 
     def __init__(
         self,

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -320,7 +320,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 26
+LIBPATCH = 27
 
 PYDEPS = ["ops>=2.0.0"]
 

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -2682,3 +2682,61 @@ class OpenSearchRequires(DataRequires):
                 event.relation, app=event.app, unit=event.unit
             )  # here check if this is the right design
             return
+
+
+class MongosRequirer(Object):
+    """Manage relations between the mongos router and the application on the application side.
+
+    Library to manage the relation for the application between mongos and the deployed application.
+    In short, this relation ensure that:
+    1. mongos receives the specified database and users roles needed by the host application
+    2. the host application receives the generated username, password and uri for connecting to the
+    sharded cluster.
+
+    This library contains the Requires and Provides classes for handling the relation between an
+    application and mongos. The mongos application relies on the MongosProvider class and the deployed
+    application uses the MongoDBRequires class.
+
+    The following is an example of how to use the MongoDBRequires class to specify the roles and
+    database name:
+
+    ```python
+    from charms.mongos.v0.mongos_client_interface import MongosRequirer
+
+
+    class ApplicationCharm(CharmBase):
+
+        def __init__(self, *args):
+            super().__init__(*args)
+
+            # relation events for mongos client
+            self._mongos_client = MongosRequirer(
+                self,
+                database_name="my-test-db",
+                extra_user_roles="admin",
+            )
+    ```
+    """
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        database_name: str,
+        extra_user_roles: str,
+        relation_name: str = "mongos_proxy",
+    ) -> None:
+        """Constructor for MongosRequirer object."""
+        self.relation_name = relation_name
+        self.charm = charm
+
+        if not database_name:
+            database_name = f"{self.charm.app}"
+
+        self.database_requires = DatabaseRequires(
+            self.charm,
+            relation_name=self.relation_name,
+            database_name=database_name,
+            extra_user_roles=extra_user_roles,
+        )
+
+        super().__init__(charm, self.relation_name)

--- a/lib/charms/data_platform_libs/v0/database_provides.py
+++ b/lib/charms/data_platform_libs/v0/database_provides.py
@@ -80,7 +80,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 logger = logging.getLogger(__name__)
 
@@ -130,7 +130,7 @@ deleted - key that were deleted"""
 class DatabaseProvides(Object):
     """Provides-side of the database relation."""
 
-    on = DatabaseEvents()  # pyright: ignore [reportGeneralTypeIssues]
+    on = DatabaseEvents()  # pyright: ignore [reportAssignmentType]
 
     def __init__(self, charm: CharmBase, relation_name: str) -> None:
         super().__init__(charm, relation_name)

--- a/lib/charms/data_platform_libs/v0/database_requires.py
+++ b/lib/charms/data_platform_libs/v0/database_requires.py
@@ -160,7 +160,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version.
-LIBPATCH = 6
+LIBPATCH = 7
 
 logger = logging.getLogger(__name__)
 
@@ -286,7 +286,7 @@ A tuple for storing the diff between two data mappings.
 class DatabaseRequires(Object):
     """Requires-side of the database relation."""
 
-    on = DatabaseEvents()  # pyright: ignore [reportGeneralTypeIssues]
+    on = DatabaseEvents()  # pyright: ignore [reportAssignmentType]
 
     def __init__(
         self,

--- a/lib/charms/data_platform_libs/v0/s3.py
+++ b/lib/charms/data_platform_libs/v0/s3.py
@@ -137,7 +137,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 logger = logging.getLogger(__name__)
 
@@ -212,7 +212,7 @@ class S3CredentialEvents(CharmEvents):
 class S3Provider(Object):
     """A provider handler for communicating S3 credentials to consumers."""
 
-    on = S3CredentialEvents()  # pyright: ignore [reportGeneralTypeIssues]
+    on = S3CredentialEvents()  # pyright: ignore [reportAssignmentType]
 
     def __init__(
         self,
@@ -613,7 +613,7 @@ S3_REQUIRED_OPTIONS = ["access-key", "secret-key"]
 class S3Requirer(Object):
     """Requires-side of the s3 relation."""
 
-    on = S3CredentialRequiresEvents()  # pyright: ignore[reportGeneralTypeIssues]
+    on = S3CredentialRequiresEvents()  # pyright: ignore[reportAssignmentType]
 
     def __init__(
         self, charm: ops.charm.CharmBase, relation_name: str, bucket_name: Optional[str] = None

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -285,7 +285,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 15
+LIBPATCH = 16
 
 PYDEPS = ["pydantic>=1.10,<2", "poetry-core"]
 
@@ -501,7 +501,7 @@ class DataUpgrade(Object, ABC):
 
     STATES = ["recovery", "failed", "idle", "ready", "upgrading", "completed"]
 
-    on = UpgradeEvents()  # pyright: ignore [reportGeneralTypeIssues]
+    on = UpgradeEvents()  # pyright: ignore [reportAssignmentType]
 
     def __init__(
         self,


### PR DESCRIPTION
## Issue:
1. DPE-3294 Requires that data-integrator charm can be integrated with the `mongos` charm. In order to be integrated with the `mongos` charm it needs access to `MongosRequirer`
2. lint deps upgraded [resulting in failing actions](https://github.com/canonical/data-platform-libs/actions/runs/7605198420)

## Solution
1. migrate `MongosRequirer` from `mongos` charm libs to `data-platform-libs`
2. update libs to be in line with new lint deps

## Future work
1. update `data-integrator` to use this lib and integrate with `mongos` suborinate charm
3. update `mongos` charm to connect using IP address when connected with data integrator charm 