### PR TITLE
[DPE-3325] Dynamically adding Peer Data Secrets (groped on-demand)

### DIFF
--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -320,7 +320,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 27
+LIBPATCH = 28
 
 PYDEPS = ["ops>=2.0.0"]
 

--- a/lib/charms/data_platform_libs/v0/data_secrets.py
+++ b/lib/charms/data_platform_libs/v0/data_secrets.py
@@ -1,6 +1,8 @@
 """Secrets related helper classes/functions."""
+
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
+
 
 from typing import Dict, Literal, Optional
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,14 +23,14 @@ def juju_has_secrets(mocker: MockerFixture):
         juju_version = version("juju")
 
     if juju_version < "3":
-        mocker.patch.object(
-            JujuVersion, "has_secrets", new_callable=PropertyMock
-        ).return_value = False
+        mocker.patch.object(JujuVersion, "has_secrets", new_callable=PropertyMock).return_value = (
+            False
+        )
         return False
     else:
-        mocker.patch.object(
-            JujuVersion, "has_secrets", new_callable=PropertyMock
-        ).return_value = True
+        mocker.patch.object(JujuVersion, "has_secrets", new_callable=PropertyMock).return_value = (
+            True
+        )
         return True
 
 

--- a/tests/integration/database-charm/actions.yaml
+++ b/tests/integration/database-charm/actions.yaml
@@ -79,6 +79,25 @@ set-peer-relation-field:
       type: string
       description: Value of the field to set
 
+set-peer-secret:
+  description: Set fields from the second-database relation
+  params:
+    component:
+      type: string
+      description: app/unit
+    field:
+      type: string
+      description: Relation field
+    value:
+      type: string
+      description: Value of the field to set
+    individual:
+      type: boolean
+      default: False
+    group:
+      type: string
+      default: ''
+
 delete-peer-relation-field:
   description: Delete fields from the sedond-database relation
   params:
@@ -95,3 +114,6 @@ delete-peer-secret:
     component:
       type: string
       description: app/unit
+    group:
+      type: string
+      default: ''

--- a/tests/integration/secrets-charm/lib/charms/data_platform_libs/v0/data_secrets.py
+++ b/tests/integration/secrets-charm/lib/charms/data_platform_libs/v0/data_secrets.py
@@ -1,6 +1,8 @@
 """Secrets related helper classes/functions."""
+
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
+
 
 from typing import Dict, Literal, Optional
 


### PR DESCRIPTION
Most charms use a single secret on `app`, and another one on `unit` level. Therefore this was the functionality provided by the `DataPeer` and the `DataPeerUnit` interfaces.

This change is extending that behavior to what is only used by a few charms (Opensearch, Pgbouncer) allowing for multiple secrets on either level. The implemetation goes in a way, that new secret fields can also form new groups or be saved into an individual secret labelled after the key.