### PR TITLE
[DPE-3450] Add expose field to requires relation

### DIFF
--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -1797,12 +1797,15 @@ class DatabaseRequestedEvent(DatabaseProvidesEvent, ExtraRoleEvent):
     """Event emitted when a new database is requested for use on this relation."""
 
     @property
-    def expose(self) -> bool:
-        """Returns the requested expose field."""
+    def external_node_connectivity(self) -> bool:
+        """Returns the requested external_node_connectivity field."""
         if not self.relation.app:
             return False
 
-        return self.relation.data[self.relation.app].get("expose", "false") == "true"
+        return (
+            self.relation.data[self.relation.app].get("external-node-connectivity", "false")
+            == "true"
+        )
 
 
 class DatabaseProvidesEvents(CharmEvents):
@@ -2022,13 +2025,13 @@ class DatabaseRequires(DataRequires):
         extra_user_roles: Optional[str] = None,
         relations_aliases: Optional[List[str]] = None,
         additional_secret_fields: Optional[List[str]] = [],
-        expose: bool = False,
+        external_node_connectivity: bool = False,
     ):
         """Manager of database client relations."""
         super().__init__(charm, relation_name, extra_user_roles, additional_secret_fields)
         self.database = database_name
         self.relations_aliases = relations_aliases
-        self.expose = expose
+        self.external_node_connectivity = external_node_connectivity
 
         # Define custom event names for each alias.
         if relations_aliases:
@@ -2184,9 +2187,9 @@ class DatabaseRequires(DataRequires):
         if self.extra_user_roles:
             event_data["extra-user-roles"] = self.extra_user_roles
 
-        # set expose field
-        if self.expose:
-            event_data["expose"] = "true"
+        # set external-node-connectivity field
+        if self.external_node_connectivity:
+            event_data["external-node-connectivity"] = "true"
 
         self.update_relation_data(event.relation.id, event_data)
 

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -1276,12 +1276,10 @@ class DataRequires(DataRelation):
         relation_name: str,
         extra_user_roles: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
-        expose: bool = False,
     ):
         """Manager of base client relations."""
         super().__init__(charm, relation_name)
         self.extra_user_roles = extra_user_roles
-        self.expose = expose
         self._secret_fields = list(self.SECRET_FIELDS)
         if additional_secret_fields:
             self._secret_fields += additional_secret_fields
@@ -1688,14 +1686,6 @@ class ExtraRoleEvent(RelationEvent):
 
         return self.relation.data[self.relation.app].get("extra-user-roles")
 
-    @property
-    def expose(self) -> bool:
-        """Returns the requested expose field."""
-        if not self.relation.app:
-            return False
-
-        return self.relation.data[self.relation.app].get("expose", "false") == "true"
-
 
 class RelationEventWithSecret(RelationEvent):
     """Base class for Relation Events that need to handle secrets."""
@@ -1805,6 +1795,14 @@ class DatabaseProvidesEvent(RelationEvent):
 
 class DatabaseRequestedEvent(DatabaseProvidesEvent, ExtraRoleEvent):
     """Event emitted when a new database is requested for use on this relation."""
+
+    @property
+    def expose(self) -> bool:
+        """Returns the requested expose field."""
+        if not self.relation.app:
+            return False
+
+        return self.relation.data[self.relation.app].get("expose", "false") == "true"
 
 
 class DatabaseProvidesEvents(CharmEvents):
@@ -2027,9 +2025,10 @@ class DatabaseRequires(DataRequires):
         expose: bool = False,
     ):
         """Manager of database client relations."""
-        super().__init__(charm, relation_name, extra_user_roles, additional_secret_fields, expose)
+        super().__init__(charm, relation_name, extra_user_roles, additional_secret_fields)
         self.database = database_name
         self.relations_aliases = relations_aliases
+        self.expose = expose
 
         # Define custom event names for each alias.
         if relations_aliases:

--- a/lib/charms/data_platform_libs/v0/data_secrets.py
+++ b/lib/charms/data_platform_libs/v0/data_secrets.py
@@ -1,4 +1,5 @@
 """Secrets related helper classes/functions."""
+
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
@@ -16,7 +17,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 
 APP_SCOPE = "app"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,14 +23,14 @@ def juju_has_secrets(mocker: MockerFixture):
         juju_version = version("juju")
 
     if juju_version < "3":
-        mocker.patch.object(
-            JujuVersion, "has_secrets", new_callable=PropertyMock
-        ).return_value = False
+        mocker.patch.object(JujuVersion, "has_secrets", new_callable=PropertyMock).return_value = (
+            False
+        )
         return False
     else:
-        mocker.patch.object(
-            JujuVersion, "has_secrets", new_callable=PropertyMock
-        ).return_value = True
+        mocker.patch.object(JujuVersion, "has_secrets", new_callable=PropertyMock).return_value = (
+            True
+        )
         return True
 
 

--- a/tests/integration/application-charm/src/charm.py
+++ b/tests/integration/application-charm/src/charm.py
@@ -74,7 +74,7 @@ class ApplicationCharm(CharmBase):
                 database_name,
                 EXTRA_USER_ROLES,
                 additional_secret_fields=["topsecret", "donttellanyone"],
-                expose=True,
+                external_node_connectivity=True,
             )
         else:
             self.second_database = DatabaseRequires(

--- a/tests/integration/application-charm/src/charm.py
+++ b/tests/integration/application-charm/src/charm.py
@@ -74,6 +74,7 @@ class ApplicationCharm(CharmBase):
                 database_name,
                 EXTRA_USER_ROLES,
                 additional_secret_fields=["topsecret", "donttellanyone"],
+                expose=True,
             )
         else:
             self.second_database = DatabaseRequires(

--- a/tests/integration/secrets-charm/lib/charms/data_platform_libs/v0/data_secrets.py
+++ b/tests/integration/secrets-charm/lib/charms/data_platform_libs/v0/data_secrets.py
@@ -1,4 +1,5 @@
 """Secrets related helper classes/functions."""
+
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -509,6 +509,21 @@ async def test_two_applications_dont_share_the_same_relation_data(
     assert application_connection_string != another_application_connection_string
 
 
+async def test_expose_field(ops_test: OpsTest, application_charm):
+    # Check that the first relation raises the flag
+    assert (
+        await get_application_relation_data(
+            ops_test, APPLICATION_APP_NAME, FIRST_DATABASE_RELATION_NAME, "expose"
+        )
+    ) == "true"
+    # Check that the flag is missing if not requested
+    assert (
+        await get_application_relation_data(
+            ops_test, APPLICATION_APP_NAME, SECOND_DATABASE_RELATION_NAME, "expose"
+        )
+    ) is None
+
+
 @pytest.mark.usefixtures("only_without_juju_secrets")
 async def test_databag_usage_correct(ops_test: OpsTest, application_charm):
     for field in ["username", "password"]:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -509,21 +509,6 @@ async def test_two_applications_dont_share_the_same_relation_data(
     assert application_connection_string != another_application_connection_string
 
 
-async def test_expose_field(ops_test: OpsTest, application_charm):
-    # Check that the first relation raises the flag
-    assert (
-        await get_application_relation_data(
-            ops_test, APPLICATION_APP_NAME, FIRST_DATABASE_RELATION_NAME, "expose"
-        )
-    ) == "true"
-    # Check that the flag is missing if not requested
-    assert (
-        await get_application_relation_data(
-            ops_test, APPLICATION_APP_NAME, SECOND_DATABASE_RELATION_NAME, "expose"
-        )
-    ) is None
-
-
 @pytest.mark.usefixtures("only_without_juju_secrets")
 async def test_databag_usage_correct(ops_test: OpsTest, application_charm):
     for field in ["username", "password"]:
@@ -636,6 +621,30 @@ async def test_an_application_can_request_multiple_databases(ops_test: OpsTest, 
 
     # Assert the two application have different relation (connection) data.
     assert first_database_connection_string != second_database_connection_string
+
+
+async def test_expose_field(ops_test: OpsTest, application_charm):
+    # Check that the flag is missing if not requested
+    assert (
+        await get_application_relation_data(
+            ops_test,
+            DATABASE_APP_NAME,
+            "database",
+            "expose",
+            related_endpoint=FIRST_DATABASE_RELATION_NAME,
+        )
+    ) is None
+
+    # Check that the second relation raises the flag
+    assert (
+        await get_application_relation_data(
+            ops_test,
+            DATABASE_APP_NAME,
+            "database",
+            "expose",
+            related_endpoint=SECOND_DATABASE_RELATION_NAME,
+        )
+    ) == "true"
 
 
 @pytest.mark.usefixtures("only_with_juju_secrets")

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -623,14 +623,14 @@ async def test_an_application_can_request_multiple_databases(ops_test: OpsTest, 
     assert first_database_connection_string != second_database_connection_string
 
 
-async def test_expose_field(ops_test: OpsTest, application_charm):
+async def test_external_node_connectivity_field(ops_test: OpsTest, application_charm):
     # Check that the flag is missing if not requested
     assert (
         await get_application_relation_data(
             ops_test,
             DATABASE_APP_NAME,
             "database",
-            "expose",
+            "external-node-connectivity",
             related_endpoint=FIRST_DATABASE_RELATION_NAME,
         )
     ) is None
@@ -641,7 +641,7 @@ async def test_expose_field(ops_test: OpsTest, application_charm):
             ops_test,
             DATABASE_APP_NAME,
             "database",
-            "expose",
+            "external-node-connectivity",
             related_endpoint=SECOND_DATABASE_RELATION_NAME,
         )
     ) == "true"

--- a/tests/unit/test_data_interfaces.py
+++ b/tests/unit/test_data_interfaces.py
@@ -275,6 +275,16 @@ class TestDatabaseProvides(DataProvidesBaseTests, unittest.TestCase):
         event = _on_database_requested.call_args[0][0]
         assert event.database == DATABASE
         assert event.extra_user_roles == EXTRA_USER_ROLES
+        assert event.expose is False
+
+        # Assert that the event will detect a raised exposed flag
+        self.harness.update_relation_data(
+            self.rel_id,
+            "application",
+            {"database": DATABASE, "expose": "true"},
+        )
+        event = _on_database_requested.call_args[0][0]
+        assert event.expose is True
 
     def test_set_endpoints(self):
         """Asserts that the endpoints are in the relation databag when they change."""

--- a/tests/unit/test_data_interfaces.py
+++ b/tests/unit/test_data_interfaces.py
@@ -275,16 +275,16 @@ class TestDatabaseProvides(DataProvidesBaseTests, unittest.TestCase):
         event = _on_database_requested.call_args[0][0]
         assert event.database == DATABASE
         assert event.extra_user_roles == EXTRA_USER_ROLES
-        assert event.expose is False
+        assert event.external_node_connectivity is False
 
-        # Assert that the event will detect a raised exposed flag
+        # Assert that the event will detect a raised external-node-connectivity flag
         self.harness.update_relation_data(
             self.rel_id,
             "application",
-            {"database": DATABASE, "expose": "true"},
+            {"database": DATABASE, "external-node-connectivity": "true"},
         )
         event = _on_database_requested.call_args[0][0]
-        assert event.expose is True
+        assert event.external_node_connectivity is True
 
     def test_set_endpoints(self):
         """Asserts that the endpoints are in the relation databag when they change."""


### PR DESCRIPTION
Adds an expose flag to the DatabaseRequires, to be consumed by subordinate router charms, so that they can know when to serve locally and when to expose the service (data-integrator).