### PR TITLE
Minor changes required for new-style Charm Design usage

### DIFF
--- a/lib/charms/data_platform_libs/v0/data_secrets.py
+++ b/lib/charms/data_platform_libs/v0/data_secrets.py
@@ -1,4 +1,5 @@
 """Secrets related helper classes/functions."""
+
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,14 +23,14 @@ def juju_has_secrets(mocker: MockerFixture):
         juju_version = version("juju")
 
     if juju_version < "3":
-        mocker.patch.object(
-            JujuVersion, "has_secrets", new_callable=PropertyMock
-        ).return_value = False
+        mocker.patch.object(JujuVersion, "has_secrets", new_callable=PropertyMock).return_value = (
+            False
+        )
         return False
     else:
-        mocker.patch.object(
-            JujuVersion, "has_secrets", new_callable=PropertyMock
-        ).return_value = True
+        mocker.patch.object(JujuVersion, "has_secrets", new_callable=PropertyMock).return_value = (
+            True
+        )
         return True
 
 

--- a/tests/integration/secrets-charm/lib/charms/data_platform_libs/v0/data_secrets.py
+++ b/tests/integration/secrets-charm/lib/charms/data_platform_libs/v0/data_secrets.py
@@ -1,4 +1,5 @@
 """Secrets related helper classes/functions."""
+
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 


### PR DESCRIPTION
These changes are required to provide full integaration with the design layed out in [Charm Structure Patterns](https://docs.google.com/document/d/1TojdN0BN3qQ1fQ_uyMd7pCL6L5NNXtFo6DrOUwU5uFI/edit?usp=sharing).

See actual usage of the lib plugged into the existing implementation of the above using the ZooKeeper Charm: https://github.com/canonical/zookeeper-operator/pull/112