### PR TITLE
[DESIGN] Separation of Concerns (Data Abstraction vs. Event Handlers)

### DIFF
--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -606,10 +606,10 @@ class SecretCache:
             logging.error("Non-existing Juju Secret was attempted to be removed %s", label)
 
 
-# Base DataRelation
+# Base Data
 
 
-class DataRelation(ABC):
+class Data(ABC):
     """Base relation data mainpulation (abstract) class."""
 
     SCOPE = Scope.APP
@@ -1033,10 +1033,10 @@ class DataRelation(ABC):
         return self._delete_relation_data(relation, fields)
 
 
-class DataRelationEventHandlers(Object):
+class EventHandlers(Object):
     """Requires-side of the relation."""
 
-    def __init__(self, charm: CharmBase, relation_data: DataRelation, unique_key: str = ""):
+    def __init__(self, charm: CharmBase, relation_data: Data, unique_key: str = ""):
         """Manager of base client relations."""
         if not unique_key:
             unique_key = relation_data.relation_name
@@ -1058,10 +1058,10 @@ class DataRelationEventHandlers(Object):
         raise NotImplementedError
 
 
-# Base DataProvides and DataRequires
+# Base ProvidesData and RequiresData
 
 
-class DataProvides(DataRelation):
+class ProvidesData(Data):
     """Base provides-side of the data products relation."""
 
     def __init__(
@@ -1302,11 +1302,11 @@ class DataProvides(DataRelation):
 
     # Public functions -- inherited
 
-    fetch_my_relation_data = leader_only(DataRelation.fetch_my_relation_data)
-    fetch_my_relation_field = leader_only(DataRelation.fetch_my_relation_field)
+    fetch_my_relation_data = leader_only(Data.fetch_my_relation_data)
+    fetch_my_relation_field = leader_only(Data.fetch_my_relation_field)
 
 
-class DataRequires(DataRelation):
+class RequiresData(Data):
     """Requires-side of the relation."""
 
     SECRET_FIELDS = ["username", "password", "tls", "tls-ca", "uris"]
@@ -1475,14 +1475,14 @@ class DataRequires(DataRelation):
 
     # Public functions -- inherited
 
-    fetch_my_relation_data = leader_only(DataRelation.fetch_my_relation_data)
-    fetch_my_relation_field = leader_only(DataRelation.fetch_my_relation_field)
+    fetch_my_relation_data = leader_only(Data.fetch_my_relation_data)
+    fetch_my_relation_field = leader_only(Data.fetch_my_relation_field)
 
 
-class DataRequiresEventHandlers(DataRelationEventHandlers):
+class RequiresEventHandlers(EventHandlers):
     """Requires-side of the relation."""
 
-    def __init__(self, charm: CharmBase, relation_data: DataRequires, unique_key: str = ""):
+    def __init__(self, charm: CharmBase, relation_data: RequiresData, unique_key: str = ""):
         """Manager of base client relations."""
         super().__init__(charm, relation_data, unique_key)
 
@@ -1519,7 +1519,7 @@ class DataRequiresEventHandlers(DataRelationEventHandlers):
 # Base DataPeer
 
 
-class DataPeerData(DataRequires, DataProvides):
+class DataPeerData(RequiresData, ProvidesData):
     """Represents peer relations data."""
 
     SECRET_FIELDS = ["operator-password"]
@@ -1536,7 +1536,7 @@ class DataPeerData(DataRequires, DataProvides):
         deleted_label: Optional[str] = None,
     ):
         """Manager of base client relations."""
-        DataRequires.__init__(
+        RequiresData.__init__(
             self,
             model,
             relation_name,
@@ -1708,14 +1708,14 @@ class DataPeerData(DataRequires, DataProvides):
 
     # Public functions -- inherited
 
-    fetch_my_relation_data = DataRelation.fetch_my_relation_data
-    fetch_my_relation_field = DataRelation.fetch_my_relation_field
+    fetch_my_relation_data = Data.fetch_my_relation_data
+    fetch_my_relation_field = Data.fetch_my_relation_field
 
 
-class DataPeerEventHandlers(DataRelationEventHandlers):
+class DataPeerEventHandlers(EventHandlers):
     """Requires-side of the relation."""
 
-    def __init__(self, charm: CharmBase, relation_data: DataRequires, unique_key: str = ""):
+    def __init__(self, charm: CharmBase, relation_data: RequiresData, unique_key: str = ""):
         """Manager of base client relations."""
         super().__init__(charm, relation_data, unique_key)
 
@@ -2076,7 +2076,7 @@ class DatabaseRequiresEvents(CharmEvents):
 # Database Provider and Requires
 
 
-class DatabaseProvidesData(DataProvides):
+class DatabaseProvidesData(ProvidesData):
     """Provider-side data of the database relations."""
 
     def __init__(self, model: Model, relation_name: str) -> None:
@@ -2154,7 +2154,7 @@ class DatabaseProvidesData(DataProvides):
         self.update_relation_data(relation_id, {"version": version})
 
 
-class DatabaseProvidesEventHandlers(DataRelationEventHandlers):
+class DatabaseProvidesEventHandlers(EventHandlers):
     """Provider-side of the database relation handlers."""
 
     on = DatabaseProvidesEvents()  # pyright: ignore [reportAssignmentType]
@@ -2191,7 +2191,7 @@ class DatabaseProvides(DatabaseProvidesData, DatabaseProvidesEventHandlers):
         DatabaseProvidesEventHandlers.__init__(self, charm, self)
 
 
-class DatabaseRequiresData(DataRequires):
+class DatabaseRequiresData(RequiresData):
     """Requires-side of the database relation."""
 
     def __init__(
@@ -2260,7 +2260,7 @@ class DatabaseRequiresData(DataRequires):
             return False
 
 
-class DatabaseRequiresEventHandlers(DataRequiresEventHandlers):
+class DatabaseRequiresEventHandlers(RequiresEventHandlers):
     """Requires-side of the relation."""
 
     on = DatabaseRequiresEvents()  # pyright: ignore [reportAssignmentType]
@@ -2563,7 +2563,7 @@ class KafkaRequiresEvents(CharmEvents):
 # Kafka Provides and Requires
 
 
-class KafkaProvidesData(DataProvides):
+class KafkaProvidesData(ProvidesData):
     """Provider-side of the Kafka relation."""
 
     def __init__(self, model: Model, relation_name: str) -> None:
@@ -2606,7 +2606,7 @@ class KafkaProvidesData(DataProvides):
         self.update_relation_data(relation_id, {"zookeeper-uris": zookeeper_uris})
 
 
-class KafkaProvidesEventHandlers(DataRelationEventHandlers):
+class KafkaProvidesEventHandlers(EventHandlers):
     """Provider-side of the Kafka relation."""
 
     on = KafkaProvidesEvents()  # pyright: ignore [reportAssignmentType]
@@ -2641,7 +2641,7 @@ class KafkaProvides(KafkaProvidesData, KafkaProvidesEventHandlers):
         KafkaProvidesEventHandlers.__init__(self, charm, self)
 
 
-class KafkaRequiresData(DataRequires):
+class KafkaRequiresData(RequiresData):
     """Requires-side of the Kafka relation."""
 
     def __init__(
@@ -2671,7 +2671,7 @@ class KafkaRequiresData(DataRequires):
         self._topic = value
 
 
-class KafkaRequiresEventHandlers(DataRequiresEventHandlers):
+class KafkaRequiresEventHandlers(RequiresEventHandlers):
     """Requires-side of the Kafka relation."""
 
     on = KafkaRequiresEvents()  # pyright: ignore [reportAssignmentType]
@@ -2809,7 +2809,7 @@ class OpenSearchRequiresEvents(CharmEvents):
 # OpenSearch Provides and Requires Objects
 
 
-class OpenSearchProvidesData(DataProvides):
+class OpenSearchProvidesData(ProvidesData):
     """Provider-side of the OpenSearch relation."""
 
     def __init__(self, model: Model, relation_name: str) -> None:
@@ -2845,7 +2845,7 @@ class OpenSearchProvidesData(DataProvides):
         self.update_relation_data(relation_id, {"version": version})
 
 
-class OpenSearchProvidesEventHandlers(DataRelationEventHandlers):
+class OpenSearchProvidesEventHandlers(EventHandlers):
     """Provider-side of the OpenSearch relation."""
 
     on = OpenSearchProvidesEvents()  # pyright: ignore[reportAssignmentType]
@@ -2879,7 +2879,7 @@ class OpenSearchProvides(OpenSearchProvidesData, OpenSearchProvidesEventHandlers
         OpenSearchProvidesEventHandlers.__init__(self, charm, self)
 
 
-class OpenSearchRequiresData(DataRequires):
+class OpenSearchRequiresData(RequiresData):
     """Requires data side of the OpenSearch relation."""
 
     def __init__(
@@ -2895,7 +2895,7 @@ class OpenSearchRequiresData(DataRequires):
         self.index = index
 
 
-class OpenSearchRequiresEventHandlers(DataRequiresEventHandlers):
+class OpenSearchRequiresEventHandlers(RequiresEventHandlers):
     """Requires events side of the OpenSearch relation."""
 
     on = OpenSearchRequiresEvents()  # pyright: ignore[reportAssignmentType]

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -625,10 +625,10 @@ class DataRelation(ABC):
 
     def __init__(
         self,
-        charm: Union[CharmBase, Model],
+        model: Model,
         relation_name: str,
     ) -> None:
-        self._model = charm.model if isinstance(charm, CharmBase) else charm
+        self._model = model
         self.local_app = self._model.app
         self.local_unit = self._model.unit
         self.relation_name = relation_name
@@ -1066,10 +1066,10 @@ class DataProvides(DataRelation):
 
     def __init__(
         self,
-        charm: CharmBase,
+        model: Model,
         relation_name: str,
     ) -> None:
-        super().__init__(charm, relation_name)
+        super().__init__(model, relation_name)
 
     def _diff(self, event: RelationChangedEvent) -> Diff:
         """Retrieves the diff of the data in the relation changed databag.
@@ -1313,13 +1313,13 @@ class DataRequires(DataRelation):
 
     def __init__(
         self,
-        charm,
+        model,
         relation_name: str,
         extra_user_roles: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
     ):
         """Manager of base client relations."""
-        super().__init__(charm, relation_name)
+        super().__init__(model, relation_name)
         self.extra_user_roles = extra_user_roles
         self._secret_fields = list(self.SECRET_FIELDS)
         if additional_secret_fields:
@@ -1528,7 +1528,7 @@ class DataPeerData(DataRequires, DataProvides):
 
     def __init__(
         self,
-        charm,
+        model,
         relation_name: str,
         extra_user_roles: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
@@ -1538,7 +1538,7 @@ class DataPeerData(DataRequires, DataProvides):
         """Manager of base client relations."""
         DataRequires.__init__(
             self,
-            charm,
+            model,
             relation_name,
             extra_user_roles,
             additional_secret_fields,
@@ -1743,7 +1743,7 @@ class DataPeer(DataPeerData, DataPeerEventHandlers):
     ):
         DataPeerData.__init__(
             self,
-            charm,
+            charm.model,
             relation_name,
             extra_user_roles,
             additional_secret_fields,
@@ -1777,7 +1777,7 @@ class DataPeerUnit(DataPeerUnitData, DataPeerEventHandlers):
     ):
         DataPeerData.__init__(
             self,
-            charm,
+            charm.model,
             relation_name,
             extra_user_roles,
             additional_secret_fields,
@@ -1821,7 +1821,7 @@ class DataPeerOtherUnit(DataPeerOtherUnitData, DataPeerOtherUnitEventHandlers):
     ):
         DataPeerData.__init__(
             self,
-            charm,
+            charm.model,
             relation_name,
             extra_user_roles,
             additional_secret_fields,
@@ -2079,8 +2079,8 @@ class DatabaseRequiresEvents(CharmEvents):
 class DatabaseProvidesData(DataProvides):
     """Provider-side data of the database relations."""
 
-    def __init__(self, charm: CharmBase, relation_name: str) -> None:
-        super().__init__(charm, relation_name)
+    def __init__(self, model: Model, relation_name: str) -> None:
+        super().__init__(model, relation_name)
 
     def set_database(self, relation_id: int, database_name: str) -> None:
         """Set database name.
@@ -2187,7 +2187,7 @@ class DatabaseProvides(DatabaseProvidesData, DatabaseProvidesEventHandlers):
     """Provider-side of the database relations."""
 
     def __init__(self, charm: CharmBase, relation_name: str) -> None:
-        DatabaseProvidesData.__init__(self, charm, relation_name)
+        DatabaseProvidesData.__init__(self, charm.model, relation_name)
         DatabaseProvidesEventHandlers.__init__(self, charm, self)
 
 
@@ -2196,7 +2196,7 @@ class DatabaseRequiresData(DataRequires):
 
     def __init__(
         self,
-        charm: Union[CharmBase, Model],
+        model: Model,
         relation_name: str,
         database_name: str,
         extra_user_roles: Optional[str] = None,
@@ -2205,7 +2205,7 @@ class DatabaseRequiresData(DataRequires):
         external_node_connectivity: bool = False,
     ):
         """Manager of database client relations."""
-        super().__init__(charm, relation_name, extra_user_roles, additional_secret_fields)
+        super().__init__(model, relation_name, extra_user_roles, additional_secret_fields)
         self.database = database_name
         self.relations_aliases = relations_aliases
         self.external_node_connectivity = external_node_connectivity
@@ -2459,7 +2459,7 @@ class DatabaseRequires(DatabaseRequiresData, DatabaseRequiresEventHandlers):
     ):
         DatabaseRequiresData.__init__(
             self,
-            charm,
+            charm.model,
             relation_name,
             database_name,
             extra_user_roles,
@@ -2566,8 +2566,8 @@ class KafkaRequiresEvents(CharmEvents):
 class KafkaProvidesData(DataProvides):
     """Provider-side of the Kafka relation."""
 
-    def __init__(self, charm: CharmBase, relation_name: str) -> None:
-        super().__init__(charm, relation_name)
+    def __init__(self, model: Model, relation_name: str) -> None:
+        super().__init__(model, relation_name)
 
     def set_topic(self, relation_id: int, topic: str) -> None:
         """Set topic name in the application relation databag.
@@ -2637,7 +2637,7 @@ class KafkaProvides(KafkaProvidesData, KafkaProvidesEventHandlers):
     """Provider-side of the Kafka relation."""
 
     def __init__(self, charm: CharmBase, relation_name: str) -> None:
-        KafkaProvidesData.__init__(self, charm, relation_name)
+        KafkaProvidesData.__init__(self, charm.model, relation_name)
         KafkaProvidesEventHandlers.__init__(self, charm, self)
 
 
@@ -2646,7 +2646,7 @@ class KafkaRequiresData(DataRequires):
 
     def __init__(
         self,
-        charm,
+        model: Model,
         relation_name: str,
         topic: str,
         extra_user_roles: Optional[str] = None,
@@ -2654,9 +2654,7 @@ class KafkaRequiresData(DataRequires):
         additional_secret_fields: Optional[List[str]] = [],
     ):
         """Manager of Kafka client relations."""
-        # super().__init__(charm, relation_name)
-        super().__init__(charm, relation_name, extra_user_roles, additional_secret_fields)
-        self.charm = charm
+        super().__init__(model, relation_name, extra_user_roles, additional_secret_fields)
         self.topic = topic
         self.consumer_group_prefix = consumer_group_prefix or ""
 
@@ -2751,7 +2749,7 @@ class KafkaRequires(KafkaRequiresData, KafkaRequiresEventHandlers):
     ) -> None:
         KafkaRequiresData.__init__(
             self,
-            charm,
+            charm.model,
             relation_name,
             topic,
             extra_user_roles,
@@ -2814,8 +2812,8 @@ class OpenSearchRequiresEvents(CharmEvents):
 class OpenSearchProvidesData(DataProvides):
     """Provider-side of the OpenSearch relation."""
 
-    def __init__(self, charm: CharmBase, relation_name: str) -> None:
-        super().__init__(charm, relation_name)
+    def __init__(self, model: Model, relation_name: str) -> None:
+        super().__init__(model, relation_name)
 
     def set_index(self, relation_id: int, index: str) -> None:
         """Set the index in the application relation databag.
@@ -2877,7 +2875,7 @@ class OpenSearchProvides(OpenSearchProvidesData, OpenSearchProvidesEventHandlers
     """Provider-side of the OpenSearch relation."""
 
     def __init__(self, charm: CharmBase, relation_name: str) -> None:
-        OpenSearchProvidesData.__init__(self, charm, relation_name)
+        OpenSearchProvidesData.__init__(self, charm.model, relation_name)
         OpenSearchProvidesEventHandlers.__init__(self, charm, self)
 
 
@@ -2886,15 +2884,14 @@ class OpenSearchRequiresData(DataRequires):
 
     def __init__(
         self,
-        charm,
+        model: Model,
         relation_name: str,
         index: str,
         extra_user_roles: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
     ):
         """Manager of OpenSearch client relations."""
-        super().__init__(charm, relation_name, extra_user_roles, additional_secret_fields)
-        self.charm = charm
+        super().__init__(model, relation_name, extra_user_roles, additional_secret_fields)
         self.index = index
 
 
@@ -3006,7 +3003,7 @@ class OpenSearchRequires(OpenSearchRequiresData, OpenSearchRequiresEventHandlers
     ) -> None:
         OpenSearchRequiresData.__init__(
             self,
-            charm,
+            charm.model,
             relation_name,
             index,
             extra_user_roles,

--- a/tests/unit/test_data_interfaces.py
+++ b/tests/unit/test_data_interfaces.py
@@ -889,10 +889,12 @@ class ApplicationCharmDatabase(CharmBase):
         )
         self.framework.observe(self.requirer.on.endpoints_changed, self._on_endpoints_changed)
         self.framework.observe(
-            self.requirer.on.read_only_endpoints_changed, self._on_read_only_endpoints_changed
+            self.requirer.on.read_only_endpoints_changed,
+            self._on_read_only_endpoints_changed,
         )
         self.framework.observe(
-            self.requirer.on.cluster1_database_created, self._on_cluster1_database_created
+            self.requirer.on.cluster1_database_created,
+            self._on_cluster1_database_created,
         )
 
     def log_relation_size(self, prefix=""):


### PR DESCRIPTION
Fully compatible with Charm Patters Design: https://github.com/canonical/zookeeper-operator/pull/121

(Backwards compatibility is confirmed by pipelines here.)

This PR implements the structure below. Allowing both for an internal separation of concerns (Data Abstraction vs. Event Handling), both for a smooth usage with [Data Interfaces Charm Patterns](https://docs.google.com/document/d/1TojdN0BN3qQ1fQ_uyMd7pCL6L5NNXtFo6DrOUwU5uFI/edit?usp=sharing) while keeping the old interface fully intact.

![Data Interfaces version Charm Structure Patterns (3)](https://github.com/canonical/data-platform-libs/assets/3271248/2f66dffd-0913-4693-b921-d014f40bdbc9)

