### PR TITLE
[DPE-3906][BUGFIX] dict implementation not supporting Python 3.9> (issue #152)

### DIFF
--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -331,7 +331,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 32
+LIBPATCH = 33
 
 PYDEPS = ["ops>=2.0.0"]
 

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -690,7 +690,7 @@ class SecretCache:
 # Base Data
 
 
-class DataDict(UserDict[str, str]):
+class DataDict(UserDict):
     """Python Standard Library 'dict' - like representation of Relation Data."""
 
     def __init__(self, relation_data: "Data", relation_id: int):
@@ -1105,7 +1105,7 @@ class Data(ABC):
     # Public interface methods
     # Handling Relation Fields seamlessly, regardless if in databag or a Juju Secret
 
-    def as_dict(self, relation_id: int) -> UserDict[str, str]:
+    def as_dict(self, relation_id: int) -> UserDict:
         """Dict behavior representation of the Abstract Data."""
         return DataDict(self, relation_id)
 


### PR DESCRIPTION
# URGENT FIX -- Python 3.9> compatiblity broken

Once again I had to remember the hard way: `data_interfaces` MUST be strongly backwards compatible.

Both in terms of code and in terms of Python versions, etc.

Adding generics to the `dict` implementation parent class broke Python 3.9> compatibility.

The proposed fix executes correctly on earlier Python versions as well: https://github.com/canonical/data-platform-libs/actions/runs/8559046518