### PR TITLE
[MISC] Fix Kafka spelling

### DIFF
--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -2834,7 +2834,7 @@ class DatabaseRequires(DatabaseRequirerData, DatabaseRequirerEventHandlers):
 # Kafka Events
 
 
-class KafkaProvidesEvent(RelationEvent):
+class KafkaProviderEvent(RelationEvent):
     """Base class for Kafka events."""
 
     @property
@@ -2854,7 +2854,7 @@ class KafkaProvidesEvent(RelationEvent):
         return self.relation.data[self.relation.app].get("consumer-group-prefix")
 
 
-class TopicRequestedEvent(KafkaProvidesEvent, ExtraRoleEvent):
+class TopicRequestedEvent(KafkaProviderEvent, ExtraRoleEvent):
     """Event emitted when a new topic is requested for use on this relation."""
 
 
@@ -2924,7 +2924,7 @@ class KafkaRequiresEvents(CharmEvents):
 # Kafka Provides and Requires
 
 
-class KafkaProvidesData(ProviderData):
+class KafkaProviderData(ProviderData):
     """Provider-side of the Kafka relation."""
 
     def __init__(self, model: Model, relation_name: str) -> None:
@@ -2967,12 +2967,12 @@ class KafkaProvidesData(ProviderData):
         self.update_relation_data(relation_id, {"zookeeper-uris": zookeeper_uris})
 
 
-class KafkaProvidesEventHandlers(EventHandlers):
+class KafkaProviderEventHandlers(EventHandlers):
     """Provider-side of the Kafka relation."""
 
     on = KafkaProvidesEvents()  # pyright: ignore [reportAssignmentType]
 
-    def __init__(self, charm: CharmBase, relation_data: KafkaProvidesData) -> None:
+    def __init__(self, charm: CharmBase, relation_data: KafkaProviderData) -> None:
         super().__init__(charm, relation_data)
         # Just to keep lint quiet, can't resolve inheritance. The same happened in super().__init__() above
         self.relation_data = relation_data
@@ -2994,12 +2994,12 @@ class KafkaProvidesEventHandlers(EventHandlers):
             )
 
 
-class KafkaProvides(KafkaProvidesData, KafkaProvidesEventHandlers):
+class KafkaProvides(KafkaProviderData, KafkaProviderEventHandlers):
     """Provider-side of the Kafka relation."""
 
     def __init__(self, charm: CharmBase, relation_name: str) -> None:
-        KafkaProvidesData.__init__(self, charm.model, relation_name)
-        KafkaProvidesEventHandlers.__init__(self, charm, self)
+        KafkaProviderData.__init__(self, charm.model, relation_name)
+        KafkaProviderEventHandlers.__init__(self, charm, self)
 
 
 class KafkaRequiresData(RequirerData):
@@ -3032,7 +3032,7 @@ class KafkaRequiresData(RequirerData):
         self._topic = value
 
 
-class KafkaRequiresEventHandlers(RequirerEventHandlers):
+class KafkaRequirerEventHandlers(RequirerEventHandlers):
     """Requires-side of the Kafka relation."""
 
     on = KafkaRequiresEvents()  # pyright: ignore [reportAssignmentType]
@@ -3096,7 +3096,7 @@ class KafkaRequiresEventHandlers(RequirerEventHandlers):
             return
 
 
-class KafkaRequires(KafkaRequiresData, KafkaRequiresEventHandlers):
+class KafkaRequires(KafkaRequiresData, KafkaRequirerEventHandlers):
     """Provider-side of the Kafka relation."""
 
     def __init__(
@@ -3117,13 +3117,13 @@ class KafkaRequires(KafkaRequiresData, KafkaRequiresEventHandlers):
             consumer_group_prefix,
             additional_secret_fields,
         )
-        KafkaRequiresEventHandlers.__init__(self, charm, self)
+        KafkaRequirerEventHandlers.__init__(self, charm, self)
 
 
 # Opensearch related events
 
 
-class OpenSearchProvidesEvent(RelationEvent):
+class OpenSearchProviderEvent(RelationEvent):
     """Base class for OpenSearch events."""
 
     @property
@@ -3135,7 +3135,7 @@ class OpenSearchProvidesEvent(RelationEvent):
         return self.relation.data[self.relation.app].get("index")
 
 
-class IndexRequestedEvent(OpenSearchProvidesEvent, ExtraRoleEvent):
+class IndexRequestedEvent(OpenSearchProviderEvent, ExtraRoleEvent):
     """Event emitted when a new index is requested for use on this relation."""
 
 
@@ -3170,7 +3170,7 @@ class OpenSearchRequiresEvents(CharmEvents):
 # OpenSearch Provides and Requires Objects
 
 
-class OpenSearchProvidesData(ProviderData):
+class OpenSearchProviderData(ProviderData):
     """Provider-side of the OpenSearch relation."""
 
     def __init__(self, model: Model, relation_name: str) -> None:
@@ -3206,12 +3206,12 @@ class OpenSearchProvidesData(ProviderData):
         self.update_relation_data(relation_id, {"version": version})
 
 
-class OpenSearchProvidesEventHandlers(EventHandlers):
+class OpenSearchProviderEventHandlers(EventHandlers):
     """Provider-side of the OpenSearch relation."""
 
     on = OpenSearchProvidesEvents()  # pyright: ignore[reportAssignmentType]
 
-    def __init__(self, charm: CharmBase, relation_data: OpenSearchProvidesData) -> None:
+    def __init__(self, charm: CharmBase, relation_data: OpenSearchProviderData) -> None:
         super().__init__(charm, relation_data)
         # Just to keep lint quiet, can't resolve inheritance. The same happened in super().__init__() above
         self.relation_data = relation_data
@@ -3232,12 +3232,12 @@ class OpenSearchProvidesEventHandlers(EventHandlers):
             )
 
 
-class OpenSearchProvides(OpenSearchProvidesData, OpenSearchProvidesEventHandlers):
+class OpenSearchProvides(OpenSearchProviderData, OpenSearchProviderEventHandlers):
     """Provider-side of the OpenSearch relation."""
 
     def __init__(self, charm: CharmBase, relation_name: str) -> None:
-        OpenSearchProvidesData.__init__(self, charm.model, relation_name)
-        OpenSearchProvidesEventHandlers.__init__(self, charm, self)
+        OpenSearchProviderData.__init__(self, charm.model, relation_name)
+        OpenSearchProviderEventHandlers.__init__(self, charm, self)
 
 
 class OpenSearchRequiresData(RequirerData):
@@ -3256,7 +3256,7 @@ class OpenSearchRequiresData(RequirerData):
         self.index = index
 
 
-class OpenSearchRequiresEventHandlers(RequirerEventHandlers):
+class OpenSearchRequirerEventHandlers(RequirerEventHandlers):
     """Requires events side of the OpenSearch relation."""
 
     on = OpenSearchRequiresEvents()  # pyright: ignore[reportAssignmentType]
@@ -3351,7 +3351,7 @@ class OpenSearchRequiresEventHandlers(RequirerEventHandlers):
             return
 
 
-class OpenSearchRequires(OpenSearchRequiresData, OpenSearchRequiresEventHandlers):
+class OpenSearchRequires(OpenSearchRequiresData, OpenSearchRequirerEventHandlers):
     """Requires-side of the OpenSearch relation."""
 
     def __init__(
@@ -3370,4 +3370,4 @@ class OpenSearchRequires(OpenSearchRequiresData, OpenSearchRequiresEventHandlers
             extra_user_roles,
             additional_secret_fields,
         )
-        OpenSearchRequiresEventHandlers.__init__(self, charm, self)
+        OpenSearchRequirerEventHandlers.__init__(self, charm, self)

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -2834,7 +2834,7 @@ class DatabaseRequires(DatabaseRequirerData, DatabaseRequirerEventHandlers):
 # Kafka Events
 
 
-class KafkaProviderEvent(RelationEvent):
+class KafkaProvidesEvent(RelationEvent):
     """Base class for Kafka events."""
 
     @property
@@ -2854,7 +2854,7 @@ class KafkaProviderEvent(RelationEvent):
         return self.relation.data[self.relation.app].get("consumer-group-prefix")
 
 
-class TopicRequestedEvent(KafkaProviderEvent, ExtraRoleEvent):
+class TopicRequestedEvent(KafkaProvidesEvent, ExtraRoleEvent):
     """Event emitted when a new topic is requested for use on this relation."""
 
 
@@ -3123,7 +3123,7 @@ class KafkaRequires(KafkaRequirerData, KafkaRequirerEventHandlers):
 # Opensearch related events
 
 
-class OpenSearchProviderEvent(RelationEvent):
+class OpenSearchProvidesEvent(RelationEvent):
     """Base class for OpenSearch events."""
 
     @property
@@ -3135,7 +3135,7 @@ class OpenSearchProviderEvent(RelationEvent):
         return self.relation.data[self.relation.app].get("index")
 
 
-class IndexRequestedEvent(OpenSearchProviderEvent, ExtraRoleEvent):
+class IndexRequestedEvent(OpenSearchProvidesEvent, ExtraRoleEvent):
     """Event emitted when a new index is requested for use on this relation."""
 
 

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -3170,7 +3170,7 @@ class OpenSearchRequiresEvents(CharmEvents):
 # OpenSearch Provides and Requires Objects
 
 
-class OpenSearchProviderData(ProviderData):
+class OpenSearchProvidesData(ProviderData):
     """Provider-side of the OpenSearch relation."""
 
     def __init__(self, model: Model, relation_name: str) -> None:
@@ -3206,12 +3206,12 @@ class OpenSearchProviderData(ProviderData):
         self.update_relation_data(relation_id, {"version": version})
 
 
-class OpenSearchProviderEventHandlers(EventHandlers):
+class OpenSearchProvidesEventHandlers(EventHandlers):
     """Provider-side of the OpenSearch relation."""
 
     on = OpenSearchProvidesEvents()  # pyright: ignore[reportAssignmentType]
 
-    def __init__(self, charm: CharmBase, relation_data: OpenSearchProviderData) -> None:
+    def __init__(self, charm: CharmBase, relation_data: OpenSearchProvidesData) -> None:
         super().__init__(charm, relation_data)
         # Just to keep lint quiet, can't resolve inheritance. The same happened in super().__init__() above
         self.relation_data = relation_data
@@ -3232,15 +3232,15 @@ class OpenSearchProviderEventHandlers(EventHandlers):
             )
 
 
-class OpenSearchProvides(OpenSearchProviderData, OpenSearchProviderEventHandlers):
+class OpenSearchProvides(OpenSearchProvidesData, OpenSearchProvidesEventHandlers):
     """Provider-side of the OpenSearch relation."""
 
     def __init__(self, charm: CharmBase, relation_name: str) -> None:
-        OpenSearchProviderData.__init__(self, charm.model, relation_name)
-        OpenSearchProviderEventHandlers.__init__(self, charm, self)
+        OpenSearchProvidesData.__init__(self, charm.model, relation_name)
+        OpenSearchProvidesEventHandlers.__init__(self, charm, self)
 
 
-class OpenSearchRequirerData(RequirerData):
+class OpenSearchRequiresData(RequirerData):
     """Requires data side of the OpenSearch relation."""
 
     def __init__(
@@ -3256,12 +3256,12 @@ class OpenSearchRequirerData(RequirerData):
         self.index = index
 
 
-class OpenSearchRequirerEventHandlers(RequirerEventHandlers):
+class OpenSearchRequiresEventHandlers(RequirerEventHandlers):
     """Requires events side of the OpenSearch relation."""
 
     on = OpenSearchRequiresEvents()  # pyright: ignore[reportAssignmentType]
 
-    def __init__(self, charm: CharmBase, relation_data: OpenSearchRequirerData) -> None:
+    def __init__(self, charm: CharmBase, relation_data: OpenSearchRequiresData) -> None:
         super().__init__(charm, relation_data)
         # Just to keep lint quiet, can't resolve inheritance. The same happened in super().__init__() above
         self.relation_data = relation_data
@@ -3351,7 +3351,7 @@ class OpenSearchRequirerEventHandlers(RequirerEventHandlers):
             return
 
 
-class OpenSearchRequires(OpenSearchRequirerData, OpenSearchRequirerEventHandlers):
+class OpenSearchRequires(OpenSearchRequiresData, OpenSearchRequiresEventHandlers):
     """Requires-side of the OpenSearch relation."""
 
     def __init__(
@@ -3362,7 +3362,7 @@ class OpenSearchRequires(OpenSearchRequirerData, OpenSearchRequirerEventHandlers
         extra_user_roles: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
     ) -> None:
-        OpenSearchRequirerData.__init__(
+        OpenSearchRequiresData.__init__(
             self,
             charm.model,
             relation_name,
@@ -3370,4 +3370,4 @@ class OpenSearchRequires(OpenSearchRequirerData, OpenSearchRequirerEventHandlers
             extra_user_roles,
             additional_secret_fields,
         )
-        OpenSearchRequirerEventHandlers.__init__(self, charm, self)
+        OpenSearchRequiresEventHandlers.__init__(self, charm, self)

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -3002,7 +3002,7 @@ class KafkaProvides(KafkaProviderData, KafkaProviderEventHandlers):
         KafkaProviderEventHandlers.__init__(self, charm, self)
 
 
-class KafkaRequiresData(RequirerData):
+class KafkaRequirerData(RequirerData):
     """Requirer-side of the Kafka relation."""
 
     def __init__(
@@ -3037,7 +3037,7 @@ class KafkaRequirerEventHandlers(RequirerEventHandlers):
 
     on = KafkaRequiresEvents()  # pyright: ignore [reportAssignmentType]
 
-    def __init__(self, charm: CharmBase, relation_data: KafkaRequiresData) -> None:
+    def __init__(self, charm: CharmBase, relation_data: KafkaRequirerData) -> None:
         super().__init__(charm, relation_data)
         # Just to keep lint quiet, can't resolve inheritance. The same happened in super().__init__() above
         self.relation_data = relation_data
@@ -3096,7 +3096,7 @@ class KafkaRequirerEventHandlers(RequirerEventHandlers):
             return
 
 
-class KafkaRequires(KafkaRequiresData, KafkaRequirerEventHandlers):
+class KafkaRequires(KafkaRequirerData, KafkaRequirerEventHandlers):
     """Provider-side of the Kafka relation."""
 
     def __init__(
@@ -3108,7 +3108,7 @@ class KafkaRequires(KafkaRequiresData, KafkaRequirerEventHandlers):
         consumer_group_prefix: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
     ) -> None:
-        KafkaRequiresData.__init__(
+        KafkaRequirerData.__init__(
             self,
             charm.model,
             relation_name,
@@ -3240,7 +3240,7 @@ class OpenSearchProvides(OpenSearchProviderData, OpenSearchProviderEventHandlers
         OpenSearchProviderEventHandlers.__init__(self, charm, self)
 
 
-class OpenSearchRequiresData(RequirerData):
+class OpenSearchRequirerData(RequirerData):
     """Requires data side of the OpenSearch relation."""
 
     def __init__(
@@ -3261,7 +3261,7 @@ class OpenSearchRequirerEventHandlers(RequirerEventHandlers):
 
     on = OpenSearchRequiresEvents()  # pyright: ignore[reportAssignmentType]
 
-    def __init__(self, charm: CharmBase, relation_data: OpenSearchRequiresData) -> None:
+    def __init__(self, charm: CharmBase, relation_data: OpenSearchRequirerData) -> None:
         super().__init__(charm, relation_data)
         # Just to keep lint quiet, can't resolve inheritance. The same happened in super().__init__() above
         self.relation_data = relation_data
@@ -3351,7 +3351,7 @@ class OpenSearchRequirerEventHandlers(RequirerEventHandlers):
             return
 
 
-class OpenSearchRequires(OpenSearchRequiresData, OpenSearchRequirerEventHandlers):
+class OpenSearchRequires(OpenSearchRequirerData, OpenSearchRequirerEventHandlers):
     """Requires-side of the OpenSearch relation."""
 
     def __init__(
@@ -3362,7 +3362,7 @@ class OpenSearchRequires(OpenSearchRequiresData, OpenSearchRequirerEventHandlers
         extra_user_roles: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
     ) -> None:
-        OpenSearchRequiresData.__init__(
+        OpenSearchRequirerData.__init__(
             self,
             charm.model,
             relation_name,


### PR DESCRIPTION
I have noticed that we have some spelling checks that do not follow the convention we have for databases. 