### PR TITLE
Fix relation data access

### DIFF
--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -331,7 +331,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 34
+LIBPATCH = 35
 
 PYDEPS = ["ops>=2.0.0"]
 
@@ -3142,10 +3142,13 @@ class KafkaRequiresEventHandlers(RequirerEventHandlers):
             return
 
         # Sets topic, extra user roles, and "consumer-group-prefix" in the relation
-        relation_data = {
-            f: getattr(self, f.replace("-", "_"), "")
-            for f in ["consumer-group-prefix", "extra-user-roles", "topic"]
-        }
+        relation_data = {"topic": self.relation_data.topic}
+
+        if self.relation_data.extra_user_roles:
+            relation_data["extra-user-roles"] = self.relation_data.extra_user_roles
+
+        if self.relation_data.consumer_group_prefix:
+            relation_data["consumer-group-prefix"] = self.relation_data.consumer_group_prefix
 
         self.relation_data.update_relation_data(event.relation.id, relation_data)
 


### PR DESCRIPTION
Copying from a comment:

Passing `self` to `getattr` means that none of those fields on the array exist on the inheritance tree from `KafkaRequiresEventHandlers`. Because of this, the lib would always write an empty string to databag, so `topic_requested` is never triggered.

Using the full `KafkaRequires` class works because we pass data indirectly to via `KafkaRequiresEventHandlers.__init__(self, charm, self)` The 3rd argument is a self reference, so `KafkaRequiresData` fields are available down the line.


NOTE: alternative, less intrusive fix
```python
relation_data = {
    f: getattr(self.relation_data, f.replace("-", "_"), "")
    for f in ["consumer-group-prefix", "extra-user-roles", "topic"]
}
```