### PR TITLE
[DPE-4530] CI testing both forward (Juju) and backwards (focal)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,7 +115,6 @@ jobs:
     needs:
       - lint
       - unit-test
-      # - build
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
@@ -146,7 +145,7 @@ jobs:
           fi
       - name: Run integration tests
         # set a predictable model name so it can be consumed by charm-logdump-action
-        run: tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}' --model testing  --dp-libs-series=${{ matrix.ubuntu-versions.series }} --dp-libs-bases-index=${{ matrix.ubuntu-versions.bases-index }}
+        run: tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}' --model testing  --os-series=${{ matrix.ubuntu-versions.series }} --build-bases-index=${{ matrix.ubuntu-versions.bases-index }}
         env:
           CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}
           LIBJUJU_VERSION_SPECIFIER: "==${{ matrix.juju-version.libjuju-version }}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,50 +58,67 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        ubuntu-versions:
+          # Update whenever charmcraft.yaml is changed
+          - series: jammy
+            bases-index: 0
+          - series: focal
+            bases-index: 1
         tox-environments:
-          - integration-database
+          - integration-db
+          - integration-upgrade-1
+          - integration-upgrade-2
+          - integration-upgrade-3
+          - integration-upgrade-4
+          # To be enabled after data_interfaces v040
+          # - integration-upgrade-5
+          # - integration-upgrade-6
+          # - integration-upgrade-7
+          - integration-upgrade-databag
           - integration-s3
           - integration-opensearch
           - integration-kafka
         juju-version:
           - juju-bootstrap-option: "2.9.44"
             juju-snap-channel: "2.9/stable"
-            libjuju-version: "2.9.42.4"
-          - juju-bootstrap-option: "3.1.6"
+            libjuju-version: "2.9.49.0"
+          - juju-bootstrap-option: "3.1.8"
             juju-snap-channel: "3.1/stable"
             libjuju-version: "3.2.2"
-        include:
-          - {tox-environments: integration-interfaces-upgrade-from-version-1-earlier,
-              juju-version:
-              {juju-snap-channel: "3.1/stable",
-                juju-bootstrap-option: "3.1.7",
-                libjuju-version: "3.2.2"}}
-          - {tox-environments: integration-interfaces-upgrade-from-version-2-earlier,
-              juju-version:
-              {juju-snap-channel: "3.1/stable",
-                juju-bootstrap-option: "3.1.7",
-                libjuju-version: "3.2.2"}}
-          - {tox-environments: integration-interfaces-upgrade-from-version-3-earlier,
-              juju-version:
-              {juju-snap-channel: "3.1/stable",
-                juju-bootstrap-option: "3.1.7",
-                libjuju-version: "3.2.2"}}
-          - {tox-environments: integration-interfaces-upgrade-from-version-4-earlier,
-              juju-version:
-              {juju-snap-channel: "3.1/stable",
-                juju-bootstrap-option: "3.1.7",
-                libjuju-version: "3.2.2"}}
-          - {tox-environments: integration-upgrades-databag-to-secrets,
-              juju-version:
-              {juju-snap-channel: "3.1/stable",
-                juju-bootstrap-option: "3.1.7",
-                libjuju-version: "3.2.2"}}
-          - {tox-environments: integration-secrets,
-              juju-version:
-              {juju-snap-channel: "3.1/stable",
-                juju-bootstrap-option: "3.1.6",
-                libjuju-version: "3.2.2"}}
-    name: ${{ matrix.tox-environments }} Juju ${{ matrix.juju-version.juju-snap-channel}} -- libjuju ${{ matrix.juju-version.libjuju-version }}
+          - juju-bootstrap-option: "3.2.4"
+            juju-snap-channel: "3.2/stable"
+            libjuju-version: "3.2.3.0"
+          - juju-bootstrap-option: "3.3.5"
+            juju-snap-channel: "3.3/stable"
+            libjuju-version: "3.3.1.1"
+          - juju-bootstrap-option: "3.4.3"
+            juju-snap-channel: "3.4/stable"
+            libjuju-version: "3.4.0.0"
+          - juju-bootstrap-option: "3.5.1"
+            juju-snap-channel: "3.5/stable"
+            libjuju-version: "3.5.0.0"
+        exclude:
+          - tox-environments: integration-upgrade-1
+            juju-version: {juju-snap-channel: "2.9/stable"}
+          - tox-environments: integration-upgrade-2
+            juju-version: {juju-snap-channel: "2.9/stable"}
+          - tox-environments: integration-upgrade-3
+            juju-version: {juju-snap-channel: "2.9/stable"}
+          - tox-environments: integration-upgrade-4
+            juju-version: {juju-snap-channel: "2.9/stable"}
+          - tox-environments: integration-upgrade-5
+            juju-version: {juju-snap-channel: "2.9/stable"}
+          - tox-environments: integration-upgrade-6
+            juju-version: {juju-snap-channel: "2.9/stable"}
+          - tox-environments: integration-upgrade-7
+            juju-version: {juju-snap-channel: "2.9/stable"}
+          - tox-environments: integration-upgrade-databag
+            juju-version: {juju-snap-channel: "2.9/stable"}
+          - tox-environments: integration-opensearch
+            ubuntu-versions: {series: focal}
+          - tox-environments: integration-kafka
+            ubuntu-versions: {series: focal}
+    name: ${{ matrix.tox-environments }} Juju ${{ matrix.juju-version.juju-snap-channel}} -- ${{ matrix.ubuntu-versions.series }}
     needs:
       - lint
       - unit-test
@@ -136,7 +153,7 @@ jobs:
           fi
       - name: Run integration tests
         # set a predictable model name so it can be consumed by charm-logdump-action
-        run: tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}' --model testing
+        run: tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}' --model testing  --dp-libs-series=${{ matrix.ubuntu-versions.series }} --dp-libs-bases-index=${{ matrix.ubuntu-versions.bases-index }}
         env:
           CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}
           LIBJUJU_VERSION_SPECIFIER: "==${{ matrix.juju-version.libjuju-version }}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,13 +47,6 @@ jobs:
         env:
           LIBJUJU_VERSION_SPECIFIER: "==${{ matrix.juju-version.libjuju-version }}"
 
-  build:
-    name: Build charms
-    needs:
-      - lint
-      - unit-test
-    uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v2
-
   integration-test:
     strategy:
       fail-fast: false
@@ -122,7 +115,7 @@ jobs:
     needs:
       - lint
       - unit-test
-      - build
+      # - build
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,21 +45,21 @@ tox                      # runs 'lint' and 'unit' environments
 
 In case your tests are re-using existing test charms with no modifications, feel free to ignore this section.
 
-For test charms that may support multiple OS versions (typically for libraries that are expected to work across
+For test charms that may support multiple Ubuntu versions (typically for libraries that are expected to work across
 legacy versions) the following mechanism is available.
 
-By default, with no parameters the first OS version is taken, that's specified in the helper charm's `charmcraft.yaml`.
+By default, with no parameters the first Ubuntu version is taken, that's specified in the helper charm's `charmcraft.yaml`.
 The current default is `jammy` with `base_index: 0` (i.e. being specified as the first `build-on/run-on` environment).
 Ordering goes in a way that newest version comes first, older ones decreasingly after.
-(This allows for meaningful defaults for helper charms for libs that only support newer/latest OS series.)
+(This allows for meaningful defaults for helper charms for libs that only support newer/latest Ubuntu series.)
 
-In case any further OS versions are to be used when executing the tests, the following `pytest` parameters are to be added
+In case any further Ubuntu versions are to be used when executing the tests, the following `pytest` parameters are to be added
 at execution time
- - `dp_libs_series`: The name of the Ubuntu series to be used for build/deploy (default: `jammy`)
- - `do_libs_base_index`: The number of item in order (counting from `0`) referring to the `db_libs_series` specified in the
+ - `os_series`: The name of the Ubuntu series to be used for build/deploy (default: `jammy`)
+ - `build_bases_index`: The number of item in order (counting from `0`) referring to the `db_libs_series` specified in the
     helper charm's `charmcraft.yaml`
 
-NOTE: In case using the mechanism above, make sure that the `dp_libs_ubuntu_series` fixture's value is passed for the
+NOTE: In case using the mechanism above, make sure that the `os_series` fixture's value is passed for the
 `series` option to your charm when deploying it in the test pipeline execution (typically: the `build_and_deploy` test function).
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ this operator.
   - code quality
   - test coverage
   - user experience for Juju administrators this charm.
-- Please help us out in ensuring easy to review branches by rebasing your pull
+- Please help us out in ensuring easy to review branches by re-basing your pull
   request branch onto the `main` branch. This also avoids merge commits and
   creates a linear Git commit history.
 
@@ -37,9 +37,31 @@ source venv/bin/activate
 tox run -e format        # update your code according to linting rules
 tox run -e lint          # code style
 tox run -e unit          # unit tests
-tox run -e integration   # integration tests
+tox run -e integration-*   # integration tests
 tox                      # runs 'lint' and 'unit' environments
 ```
+
+### Adding new tests
+
+In case your tests are re-using existing test charms with no modifications, feel free to ignore this section.
+
+For test charms that may support multiple OS versions (typically for libraries that are expected to work across
+legacy versions) the following mechanism is available.
+
+By default, with no parameters the first OS version is taken, that's specified in the helper charm's `charmcraft.yaml`.
+The current default is `jammy` with `base_index: 0` (i.e. being specified as the first `build-on/run-on` environment).
+Ordering goes in a way that newest version comes first, older ones decreasingly after.
+(This allows for meaningful defaults for helper charms for libs that only support newer/latest OS series.)
+
+In case any further OS versions are to be used when executing the tests, the following `pytest` parameters are to be added
+at execution time
+ - `dp_libs_series`: The name of the Ubuntu series to be used for build/deploy (default: `jammy`)
+ - `do_libs_base_index`: The number of item in order (counting from `0`) referring to the `db_libs_series` specified in the
+    helper charm's `charmcraft.yaml`
+
+NOTE: In case using the mechanism above, make sure that the `dp_libs_ubuntu_series` fixture's value is passed for the
+`series` option to your charm when deploying it in the test pipeline execution (typically: the `build_and_deploy` test function).
+
 
 ## Build charm
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -11,8 +11,8 @@ parts:
       - cargo
 bases:
   - build-on:
-    - name: "ubuntu"
-      channel: "22.04"
+      - name: "ubuntu"
+        channel: "22.04"
     run-on:
-    - name: "ubuntu"
-      channel: "22.04"
+      - name: "ubuntu"
+        channel: "22.04"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
+import argparse
 import os
 from importlib.metadata import version
 from unittest.mock import PropertyMock
@@ -7,6 +8,32 @@ from unittest.mock import PropertyMock
 import pytest
 from ops import JujuVersion
 from pytest_mock import MockerFixture
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--dp-libs-series", help="Ubuntu series for dp libs charm (e.g. jammy)", default="jammy"
+    )
+    parser.addoption(
+        "--dp-libs-bases-index",
+        type=int,
+        help="Index of charmcraft.yaml base that matches --dp-libs-series",
+        default=0,
+    )
+
+
+def pytest_configure(config):
+    if (config.option.dp_libs_series is None) ^ (config.option.dp_libs_bases_index is None):
+        raise argparse.ArgumentError(
+            None,
+            "--dp-libs-series and --dp-libs-bases-index must be given together",
+        )
+    # Note: Update defaults whenever charmcraft.yaml is changed
+    valid_combinations = [(0, "jammy"), (1, "focal")]
+    if (config.option.dp_libs_bases_index, config.option.dp_libs_series) not in valid_combinations:
+        raise argparse.ArgumentError(
+            None, f"Only base index combinations {valid_combinations} are accepted."
+        )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,25 +12,25 @@ from pytest_mock import MockerFixture
 
 def pytest_addoption(parser):
     parser.addoption(
-        "--dp-libs-series", help="Ubuntu series for dp libs charm (e.g. jammy)", default="jammy"
+        "--os-series", help="Ubuntu series for dp libs charm (e.g. jammy)", default="jammy"
     )
     parser.addoption(
-        "--dp-libs-bases-index",
+        "--build-bases-index",
         type=int,
-        help="Index of charmcraft.yaml base that matches --dp-libs-series",
+        help="Index of charmcraft.yaml base that matches --os-series",
         default=0,
     )
 
 
 def pytest_configure(config):
-    if (config.option.dp_libs_series is None) ^ (config.option.dp_libs_bases_index is None):
+    if (config.option.os_series is None) ^ (config.option.build_bases_index is None):
         raise argparse.ArgumentError(
             None,
-            "--dp-libs-series and --dp-libs-bases-index must be given together",
+            "--os-series and --build-bases-index must be given together",
         )
     # Note: Update defaults whenever charmcraft.yaml is changed
     valid_combinations = [(0, "jammy"), (1, "focal")]
-    if (config.option.dp_libs_bases_index, config.option.dp_libs_series) not in valid_combinations:
+    if (config.option.build_bases_index, config.option.os_series) not in valid_combinations:
         raise argparse.ArgumentError(
             None, f"Only base index combinations {valid_combinations} are accepted."
         )

--- a/tests/integration/application-charm/charmcraft.yaml
+++ b/tests/integration/application-charm/charmcraft.yaml
@@ -3,12 +3,21 @@
 
 type: charm
 bases:
+  # Whenever "bases" is changed:
+  # - Update tests/integration/conftest.py::pytest_configure()
+  # - Update .github/workflow/ci.yaml integration-test matrix
   - build-on:
       - name: "ubuntu"
         channel: "22.04"
     run-on:
       - name: "ubuntu"
         channel: "22.04"
+  - build-on:
+      - name: "ubuntu"
+        channel: "20.04"
+    run-on:
+      - name: "ubuntu"
+        channel: "20.04"
 parts:
   charm:
     charm-binary-python-packages:

--- a/tests/integration/application-s3-charm/charmcraft.yaml
+++ b/tests/integration/application-s3-charm/charmcraft.yaml
@@ -3,9 +3,18 @@
 
 type: charm
 bases:
+  # Whenever "bases" is changed:
+  # - Update tests/integration/conftest.py::pytest_configure()
+  # - Update .github/workflow/ci.yaml integration-test matrix
   - build-on:
       - name: "ubuntu"
         channel: "22.04"
     run-on:
       - name: "ubuntu"
         channel: "22.04"
+  - build-on:
+      - name: "ubuntu"
+        channel: "20.04"
+    run-on:
+      - name: "ubuntu"
+        channel: "20.04"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -17,8 +17,8 @@ logger = logging.getLogger(__name__)
 
 @pytest.fixture(scope="session")
 def dp_libs_ubuntu_series(pytestconfig) -> str:
-    if pytestconfig.option.dp_libs_series:
-        return pytestconfig.option.dp_libs_series
+    if pytestconfig.option.os_series:
+        return pytestconfig.option.os_series
 
 
 @pytest.fixture(scope="module")
@@ -33,14 +33,14 @@ def ops_test(ops_test: OpsTest, pytestconfig) -> OpsTest:
     # Add bases_index option (indicating which OS version to use)
     # when building the charm within the scope of the test run
     async def build_charm(charm_path, bases_index: int = None) -> Path:
-        if not bases_index and pytestconfig.option.dp_libs_bases_index:
-            bases_index = pytestconfig.option.dp_libs_bases_index
+        if not bases_index and pytestconfig.option.build_bases_index:
+            bases_index = pytestconfig.option.build_bases_index
 
         logger.info(f"Building charm {charm_path} with base index {bases_index}")
 
         return await _build_charm(
             charm_path,
-            bases_index=pytestconfig.option.dp_libs_bases_index,
+            bases_index=pytestconfig.option.build_bases_index,
         )
 
     ops_test.build_charm = build_charm

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,7 +2,7 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import json
+import logging
 import os
 import shutil
 from datetime import datetime
@@ -12,22 +12,38 @@ from subprocess import check_call, check_output
 import pytest
 from pytest_operator.plugin import OpsTest
 
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="session")
+def dp_libs_ubuntu_series(pytestconfig) -> str:
+    if pytestconfig.option.dp_libs_series:
+        return pytestconfig.option.dp_libs_series
+
 
 @pytest.fixture(scope="module")
-def ops_test(ops_test: OpsTest) -> OpsTest:
-    if os.environ.get("CI") == "true":
-        # Running in GitHub Actions; skip build step
-        # (GitHub Actions uses a separate, cached build step. See .github/workflows/ci.yaml)
-        packed_charms = json.loads(os.environ["CI_PACKED_CHARMS"])
+def ops_test(ops_test: OpsTest, pytestconfig) -> OpsTest:
+    """Re-defining OpsTest.build_charm in a way that it takes CI caching and build parameters into account.
 
-        async def build_charm(charm_path, bases_index: int = None) -> Path:
-            for charm in packed_charms:
-                if Path(charm_path) == Path(charm["directory_path"]):
-                    if bases_index is None or bases_index == charm["bases_index"]:
-                        return charm["file_path"]
-            raise ValueError(f"Unable to find .charm file for {bases_index=} at {charm_path=}")
+    Build parameters (for charms available for multiple OS versions) are considered both when building the
+    charm, or when fetching pre-built, CI cached version of it.
+    """
+    _build_charm = ops_test.build_charm
 
-        ops_test.build_charm = build_charm
+    # Add bases_index option (indicating which OS version to use)
+    # when building the charm within the scope of the test run
+    async def build_charm(charm_path, bases_index: int = None) -> Path:
+        if not bases_index and pytestconfig.option.dp_libs_bases_index:
+            bases_index = pytestconfig.option.dp_libs_bases_index
+
+        logger.info(f"Building charm {charm_path} with base index {bases_index}")
+
+        return await _build_charm(
+            charm_path,
+            bases_index=pytestconfig.option.dp_libs_bases_index,
+        )
+
+    ops_test.build_charm = build_charm
     return ops_test
 
 
@@ -169,7 +185,7 @@ def fetch_old_versions():
     check_call("git clone https://github.com/canonical/data-platform-libs.git", shell=True)
     os.chdir("data-platform-libs")
     last_commits = check_output(
-        "git show --pretty=format:'%h' --no-patch -15", shell=True, universal_newlines=True
+        "git show --pretty=format:'%h' --no-patch -25", shell=True, universal_newlines=True
     ).split()
 
     versions = []
@@ -185,7 +201,7 @@ def fetch_old_versions():
             shutil.copyfile(src_path, f"{data_path}.v{version}")
             versions.append(version)
 
-        if len(versions) == 4:
+        if len(versions) == 7:
             break
 
     os.chdir(cwd)

--- a/tests/integration/database-charm/charmcraft.yaml
+++ b/tests/integration/database-charm/charmcraft.yaml
@@ -3,12 +3,21 @@
 
 type: charm
 bases:
+  # Whenever "bases" is changed:
+  # - Update tests/integration/conftest.py::pytest_configure()
+  # - Update .github/workflow/ci.yaml integration-test matrix
   - build-on:
       - name: "ubuntu"
         channel: "22.04"
     run-on:
       - name: "ubuntu"
         channel: "22.04"
+  - build-on:
+      - name: "ubuntu"
+        channel: "20.04"
+    run-on:
+      - name: "ubuntu"
+        channel: "20.04"
 parts:
   charm:
     charm-binary-python-packages: [psycopg2-binary==2.9.3]

--- a/tests/integration/database-charm/src/charm.py
+++ b/tests/integration/database-charm/src/charm.py
@@ -13,6 +13,7 @@ import secrets
 import string
 from random import randrange
 from time import sleep
+from typing import Optional
 
 import psycopg2
 from ops import Relation
@@ -119,7 +120,7 @@ class DatabaseCharm(CharmBase):
         )
 
     @property
-    def peer_relation(self) -> Relation | None:
+    def peer_relation(self) -> Optional[Relation]:
         """The cluster peer relation."""
         return self.model.get_relation(PEER)
 

--- a/tests/integration/dummy-database-charm/charmcraft.yaml
+++ b/tests/integration/dummy-database-charm/charmcraft.yaml
@@ -3,12 +3,21 @@
 
 type: charm
 bases:
+  # Whenever "bases" is changed:
+  # - Update tests/integration/conftest.py::pytest_configure()
+  # - Update .github/workflow/ci.yaml integration-test matrix
   - build-on:
       - name: "ubuntu"
         channel: "22.04"
     run-on:
       - name: "ubuntu"
         channel: "22.04"
+  - build-on:
+      - name: "ubuntu"
+        channel: "20.04"
+    run-on:
+      - name: "ubuntu"
+        channel: "20.04"
 parts:
   charm:
     charm-binary-python-packages: [psycopg2-binary==2.9.3]

--- a/tests/integration/dummy-database-charm/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/tests/integration/dummy-database-charm/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -331,7 +331,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 32
+LIBPATCH = 37
 
 PYDEPS = ["ops>=2.0.0"]
 
@@ -493,6 +493,7 @@ def leader_only(f):
             return
         return f(self, *args, **kwargs)
 
+    wrapper.leader_only = True
     return wrapper
 
 
@@ -559,6 +560,7 @@ class CachedSecret:
         component: Union[Application, Unit],
         label: str,
         secret_uri: Optional[str] = None,
+        legacy_labels: List[str] = [],
     ):
         self._secret_meta = None
         self._secret_content = {}
@@ -566,16 +568,25 @@ class CachedSecret:
         self.label = label
         self._model = model
         self.component = component
+        self.legacy_labels = legacy_labels
+        self.current_label = None
 
-    def add_secret(self, content: Dict[str, str], relation: Relation) -> Secret:
+    def add_secret(
+        self,
+        content: Dict[str, str],
+        relation: Optional[Relation] = None,
+        label: Optional[str] = None,
+    ) -> Secret:
         """Create a new secret."""
         if self._secret_uri:
             raise SecretAlreadyExistsError(
                 "Secret is already defined with uri %s", self._secret_uri
             )
 
-        secret = self.component.add_secret(content, label=self.label)
-        if relation.app != self._model.app:
+        label = self.label if not label else label
+
+        secret = self.component.add_secret(content, label=label)
+        if relation and relation.app != self._model.app:
             # If it's not a peer relation, grant is to be applied
             secret.grant(relation)
         self._secret_uri = secret.id
@@ -588,13 +599,20 @@ class CachedSecret:
         if not self._secret_meta:
             if not (self._secret_uri or self.label):
                 return
-            try:
-                self._secret_meta = self._model.get_secret(label=self.label)
-            except SecretNotFoundError:
-                if self._secret_uri:
-                    self._secret_meta = self._model.get_secret(
-                        id=self._secret_uri, label=self.label
-                    )
+
+            for label in [self.label] + self.legacy_labels:
+                try:
+                    self._secret_meta = self._model.get_secret(label=label)
+                except SecretNotFoundError:
+                    pass
+                else:
+                    if label != self.label:
+                        self.current_label = label
+                    break
+
+            # If still not found, to be checked by URI, to be labelled with the proposed label
+            if not self._secret_meta and self._secret_uri:
+                self._secret_meta = self._model.get_secret(id=self._secret_uri, label=self.label)
         return self._secret_meta
 
     def get_content(self) -> Dict[str, str]:
@@ -618,12 +636,34 @@ class CachedSecret:
                     self._secret_content = self.meta.get_content()
         return self._secret_content
 
+    def _move_to_new_label_if_needed(self):
+        """Helper function to re-create the secret with a different label."""
+        if not self.current_label or not (self.meta and self._secret_meta):
+            return
+
+        # Create a new secret with the new label
+        content = self._secret_meta.get_content()
+        self._secret_uri = None
+
+        # I wish we could just check if we are the owners of the secret...
+        try:
+            self._secret_meta = self.add_secret(content, label=self.label)
+        except ModelError as err:
+            if "this unit is not the leader" not in str(err):
+                raise
+        self.current_label = None
+
     def set_content(self, content: Dict[str, str]) -> None:
         """Setting cached secret content."""
         if not self.meta:
             return
 
+        # DPE-4182: do not create new revision if the content stay the same
+        if content == self.get_content():
+            return
+
         if content:
+            self._move_to_new_label_if_needed()
             self.meta.set_content(content)
             self._secret_content = content
         else:
@@ -655,10 +695,14 @@ class SecretCache:
         self.component = component
         self._secrets: Dict[str, CachedSecret] = {}
 
-    def get(self, label: str, uri: Optional[str] = None) -> Optional[CachedSecret]:
+    def get(
+        self, label: str, uri: Optional[str] = None, legacy_labels: List[str] = []
+    ) -> Optional[CachedSecret]:
         """Getting a secret from Juju Secret store or cache."""
         if not self._secrets.get(label):
-            secret = CachedSecret(self._model, self.component, label, uri)
+            secret = CachedSecret(
+                self._model, self.component, label, uri, legacy_labels=legacy_labels
+            )
             if secret.meta:
                 self._secrets[label] = secret
         return self._secrets.get(label)
@@ -676,10 +720,14 @@ class SecretCache:
     def remove(self, label: str) -> None:
         """Remove a secret from the cache."""
         if secret := self.get(label):
-            secret.remove()
-            self._secrets.pop(label)
-        else:
-            logging.error("Non-existing Juju Secret was attempted to be removed %s", label)
+            try:
+                secret.remove()
+                self._secrets.pop(label)
+            except (SecretsUnavailableError, KeyError):
+                pass
+            else:
+                return
+        logging.debug("Non-existing Juju Secret was attempted to be removed %s", label)
 
 
 ################################################################################
@@ -690,7 +738,7 @@ class SecretCache:
 # Base Data
 
 
-class DataDict(UserDict[str, str]):
+class DataDict(UserDict):
     """Python Standard Library 'dict' - like representation of Relation Data."""
 
     def __init__(self, relation_data: "Data", relation_id: int):
@@ -716,11 +764,21 @@ class DataDict(UserDict[str, str]):
     def __getitem__(self, key: str) -> str:
         """Get an item of the Abstract Relation Data dictionary."""
         result = None
-        if not (result := self.relation_data.fetch_my_relation_field(self.relation_id, key)):
+
+        # Avoiding "leader_only" error when cross-charm non-leader unit, not to report useless error
+        if (
+            not hasattr(self.relation_data.fetch_my_relation_field, "leader_only")
+            or self.relation_data.component != self.relation_data.local_app
+            or self.relation_data.local_unit.is_leader()
+        ):
+            result = self.relation_data.fetch_my_relation_field(self.relation_id, key)
+
+        if not result:
             try:
                 result = self.relation_data.fetch_relation_field(self.relation_id, key)
             except NotImplementedError:
                 pass
+
         if not result:
             raise KeyError
         return result
@@ -1095,7 +1153,7 @@ class Data(ABC):
             try:
                 relation.data[component].pop(field)
             except KeyError:
-                logger.error(
+                logger.debug(
                     "Non-existing field '%s' was attempted to be removed from the databag (relation ID: %s)",
                     str(field),
                     str(relation.id),
@@ -1105,7 +1163,7 @@ class Data(ABC):
     # Public interface methods
     # Handling Relation Fields seamlessly, regardless if in databag or a Juju Secret
 
-    def as_dict(self, relation_id: int) -> UserDict[str, str]:
+    def as_dict(self, relation_id: int) -> UserDict:
         """Dict behavior representation of the Abstract Data."""
         return DataDict(self, relation_id)
 
@@ -1351,7 +1409,7 @@ class ProviderData(Data):
             try:
                 new_content.pop(field)
             except KeyError:
-                logging.error(
+                logging.debug(
                     "Non-existing secret was attempted to be removed %s, %s",
                     str(relation.id),
                     str(field),
@@ -1532,7 +1590,7 @@ class RequirerData(Data):
         """
         label = self._generate_secret_label(relation_name, relation_id, group)
 
-        # Fetchin the Secret's meta information ensuring that it's locally getting registered with
+        # Fetching the Secret's meta information ensuring that it's locally getting registered with
         CachedSecret(self._model, self.component, label, secret_id).meta
 
     def _register_secrets_to_relation(self, relation: Relation, params_name_list: List[str]):
@@ -1723,6 +1781,7 @@ class DataPeerData(RequirerData, ProviderData):
         self._secret_label_map = {}
         # Secrets that are being dynamically added within the scope of this event handler run
         self._new_secrets = []
+        self._additional_secret_group_mapping = additional_secret_group_mapping
 
         for group, fields in additional_secret_group_mapping.items():
             if group not in SECRET_GROUPS.groups():
@@ -1769,12 +1828,15 @@ class DataPeerData(RequirerData, ProviderData):
 
         relation = self._model.relations[self.relation_name][0]
         fields = []
+
+        ignores = [SECRET_GROUPS.get_group("user"), SECRET_GROUPS.get_group("tls")]
         for group in SECRET_GROUPS.groups():
+            if group in ignores:
+                continue
             if content := self._get_group_secret_contents(relation, group):
-                fields += [self._field_to_internal_name(field, group) for field in content]
+                fields += list(content.keys())
         return list(set(fields) | set(self._new_secrets))
 
-    @juju_secrets_only
     @dynamic_secrets_only
     def set_secret(
         self,
@@ -1792,13 +1854,13 @@ class DataPeerData(RequirerData, ProviderData):
             group_mapping: The name of the "secret group", in case the field is to be added to an existing secret
         """
         full_field = self._field_to_internal_name(field, group_mapping)
-        if full_field not in self.current_secret_fields:
+        if self.secrets_enabled and full_field not in self.current_secret_fields:
             self._new_secrets.append(full_field)
-        self.update_relation_data(relation_id, {full_field: value})
+        if self._no_group_with_databag(field, full_field):
+            self.update_relation_data(relation_id, {full_field: value})
 
     # Unlike for set_secret(), there's no harm using this operation with static secrets
     # The restricion is only added to keep the concept clear
-    @juju_secrets_only
     @dynamic_secrets_only
     def get_secret(
         self,
@@ -1808,13 +1870,15 @@ class DataPeerData(RequirerData, ProviderData):
     ) -> Optional[str]:
         """Public interface method to fetch secrets only."""
         full_field = self._field_to_internal_name(field, group_mapping)
-        if full_field not in self.current_secret_fields:
-            raise SecretsUnavailableError(
-                f"Secret {field} from group {group_mapping} was not found"
-            )
-        return self.fetch_my_relation_field(relation_id, full_field)
+        if (
+            self.secrets_enabled
+            and full_field not in self.current_secret_fields
+            and field not in self.current_secret_fields
+        ):
+            return
+        if self._no_group_with_databag(field, full_field):
+            return self.fetch_my_relation_field(relation_id, full_field)
 
-    @juju_secrets_only
     @dynamic_secrets_only
     def delete_secret(
         self,
@@ -1824,9 +1888,11 @@ class DataPeerData(RequirerData, ProviderData):
     ) -> Optional[str]:
         """Public interface method to delete secrets only."""
         full_field = self._field_to_internal_name(field, group_mapping)
-        if full_field not in self.current_secret_fields:
+        if self.secrets_enabled and full_field not in self.current_secret_fields:
             logger.warning(f"Secret {field} from group {group_mapping} was not found")
-        self.delete_relation_data(relation_id, [full_field])
+            return
+        if self._no_group_with_databag(field, full_field):
+            self.delete_relation_data(relation_id, [full_field])
 
     # Helpers
 
@@ -1870,6 +1936,73 @@ class DataPeerData(RequirerData, ProviderData):
             if k in self.secret_fields
         }
 
+    # Backwards compatibility
+
+    def _check_deleted_label(self, relation, fields) -> None:
+        """Helper function for legacy behavior."""
+        current_data = self.fetch_my_relation_data([relation.id], fields)
+        if current_data is not None:
+            # Check if the secret we wanna delete actually exists
+            # Given the "deleted label", here we can't rely on the default mechanism (i.e. 'key not found')
+            if non_existent := (set(fields) & set(self.secret_fields)) - set(
+                current_data.get(relation.id, [])
+            ):
+                logger.debug(
+                    "Non-existing secret %s was attempted to be removed.",
+                    ", ".join(non_existent),
+                )
+
+    def _remove_secret_from_databag(self, relation, fields: List[str]) -> None:
+        """For Rolling Upgrades -- when moving from databag to secrets usage.
+
+        Practically what happens here is to remove stuff from the databag that is
+        to be stored in secrets.
+        """
+        if not self.secret_fields:
+            return
+
+        secret_fields_passed = set(self.secret_fields) & set(fields)
+        for field in secret_fields_passed:
+            if self._fetch_relation_data_without_secrets(self.component, relation, [field]):
+                self._delete_relation_data_without_secrets(self.component, relation, [field])
+
+    def _remove_secret_field_name_from_databag(self, relation) -> None:
+        """Making sure that the old databag URI is gone.
+
+        This action should not be executed more than once.
+        """
+        # Nothing to do if 'internal-secret' is not in the databag
+        if not (relation.data[self.component].get(self._generate_secret_field_name())):
+            return
+
+        # Making sure that the secret receives its label
+        # (This should have happened by the time we get here, rather an extra security measure.)
+        secret = self._get_relation_secret(relation.id)
+
+        # Either app scope secret with leader executing, or unit scope secret
+        leader_or_unit_scope = self.component != self.local_app or self.local_unit.is_leader()
+        if secret and leader_or_unit_scope:
+            # Databag reference to the secret URI can be removed, now that it's labelled
+            relation.data[self.component].pop(self._generate_secret_field_name(), None)
+
+    def _previous_labels(self) -> List[str]:
+        """Generator for legacy secret label names, for backwards compatibility."""
+        result = []
+        members = [self._model.app.name]
+        if self.scope:
+            members.append(self.scope.value)
+        result.append(f"{'.'.join(members)}")
+        return result
+
+    def _no_group_with_databag(self, field: str, full_field: str) -> bool:
+        """Check that no secret group is attempted to be used together with databag."""
+        if not self.secrets_enabled and full_field != field:
+            logger.error(
+                f"Can't access {full_field}: no secrets available (i.e. no secret groups either)."
+            )
+            return False
+        return True
+
     # Event handlers
 
     def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
@@ -1885,7 +2018,7 @@ class DataPeerData(RequirerData, ProviderData):
     def _generate_secret_label(
         self, relation_name: str, relation_id: int, group_mapping: SecretGroup
     ) -> str:
-        members = [self._model.app.name]
+        members = [relation_name, self._model.app.name]
         if self.scope:
             members.append(self.scope.value)
         if group_mapping != SECRET_GROUPS.EXTRA:
@@ -1919,16 +2052,12 @@ class DataPeerData(RequirerData, ProviderData):
         label = self._generate_secret_label(relation_name, relation_id, group_mapping)
         secret_uri = relation.data[self.component].get(self._generate_secret_field_name(), None)
 
-        # Fetching the secret with fallback to URI (in case label is not yet known)
-        # Label would we "stuck" on the secret in case it is found
-        secret = self.secrets.get(label, secret_uri)
-
-        # Either app scope secret with leader executing, or unit scope secret
-        leader_or_unit_scope = self.component != self.local_app or self.local_unit.is_leader()
-        if secret_uri and secret and leader_or_unit_scope:
-            # Databag reference to the secret URI can be removed, now that it's labelled
-            relation.data[self.component].pop(self._generate_secret_field_name(), None)
-        return secret
+        # URI or legacy label is only to applied when moving single legacy secret to a (new) label
+        if group_mapping == SECRET_GROUPS.EXTRA:
+            # Fetching the secret with fallback to URI (in case label is not yet known)
+            # Label would we "stuck" on the secret in case it is found
+            return self.secrets.get(label, secret_uri, legacy_labels=self._previous_labels())
+        return self.secrets.get(label)
 
     def _get_group_secret_contents(
         self,
@@ -1939,27 +2068,11 @@ class DataPeerData(RequirerData, ProviderData):
         """Helper function to retrieve collective, requested contents of a secret."""
         secret_fields = [self._internal_name_to_field(k)[0] for k in secret_fields]
         result = super()._get_group_secret_contents(relation, group, secret_fields)
-        if not self.deleted_label:
-            return result
-        return {
-            self._field_to_internal_name(key, group): result[key]
-            for key in result
-            if result[key] != self.deleted_label
-        }
-
-    def _remove_secret_from_databag(self, relation, fields: List[str]) -> None:
-        """For Rolling Upgrades -- when moving from databag to secrets usage.
-
-        Practically what happens here is to remove stuff from the databag that is
-        to be stored in secrets.
-        """
-        if not self.secret_fields:
-            return
-
-        secret_fields_passed = set(self.secret_fields) & set(fields)
-        for field in secret_fields_passed:
-            if self._fetch_relation_data_without_secrets(self.component, relation, [field]):
-                self._delete_relation_data_without_secrets(self.component, relation, [field])
+        if self.deleted_label:
+            result = {key: result[key] for key in result if result[key] != self.deleted_label}
+        if self._additional_secret_group_mapping:
+            return {self._field_to_internal_name(key, group): result[key] for key in result}
+        return result
 
     @either_static_or_dynamic_secrets
     def _fetch_my_specific_relation_data(
@@ -1982,6 +2095,7 @@ class DataPeerData(RequirerData, ProviderData):
             data=data,
             uri_to_databag=False,
         )
+        self._remove_secret_field_name_from_databag(relation)
 
         normal_content = {k: v for k, v in data.items() if k in normal_fields}
         self._update_relation_data_without_secrets(self.component, relation, normal_content)
@@ -1990,17 +2104,8 @@ class DataPeerData(RequirerData, ProviderData):
     def _delete_relation_data(self, relation: Relation, fields: List[str]) -> None:
         """Delete data available (directily or indirectly -- i.e. secrets) from the relation for owner/this_app."""
         if self.secret_fields and self.deleted_label:
-            current_data = self.fetch_my_relation_data([relation.id], fields)
-            if current_data is not None:
-                # Check if the secret we wanna delete actually exists
-                # Given the "deleted label", here we can't rely on the default mechanism (i.e. 'key not found')
-                if non_existent := (set(fields) & set(self.secret_fields)) - set(
-                    current_data.get(relation.id, [])
-                ):
-                    logger.error(
-                        "Non-existing secret %s was attempted to be removed.",
-                        ", ".join(non_existent),
-                    )
+            # Legacy, backwards compatibility
+            self._check_deleted_label(relation, fields)
 
             _, normal_fields = self._process_secret_fields(
                 relation,
@@ -2036,19 +2141,10 @@ class DataPeerData(RequirerData, ProviderData):
             "fetch_my_relation_data() and fetch_my_relation_field()"
         )
 
-    def fetch_my_relation_field(
-        self, relation_id: int, field: str, relation_name: Optional[str] = None
-    ) -> Optional[str]:
-        """Get a single field from the relation data -- owner side.
-
-        Re-implementing the inherited function due to field@group conversion
-        """
-        if relation_data := self.fetch_my_relation_data([relation_id], [field], relation_name):
-            return relation_data.get(relation_id, {}).get(self._internal_name_to_field(field)[0])
-
     # Public functions -- inherited
 
     fetch_my_relation_data = Data.fetch_my_relation_data
+    fetch_my_relation_field = Data.fetch_my_relation_field
 
 
 class DataPeerEventHandlers(RequirerEventHandlers):
@@ -2217,7 +2313,7 @@ class RelationEventWithSecret(RelationEvent):
         return self._cached_secrets
 
     def _get_secret(self, group) -> Optional[Dict[str, str]]:
-        """Retrieveing secrets."""
+        """Retrieving secrets."""
         if not self.app:
             return
         if not self._secrets.get(group):
@@ -2924,7 +3020,7 @@ class KafkaRequiresEvents(CharmEvents):
 # Kafka Provides and Requires
 
 
-class KafkaProvidesData(ProviderData):
+class KafkaProviderData(ProviderData):
     """Provider-side of the Kafka relation."""
 
     def __init__(self, model: Model, relation_name: str) -> None:
@@ -2967,12 +3063,12 @@ class KafkaProvidesData(ProviderData):
         self.update_relation_data(relation_id, {"zookeeper-uris": zookeeper_uris})
 
 
-class KafkaProvidesEventHandlers(EventHandlers):
+class KafkaProviderEventHandlers(EventHandlers):
     """Provider-side of the Kafka relation."""
 
     on = KafkaProvidesEvents()  # pyright: ignore [reportAssignmentType]
 
-    def __init__(self, charm: CharmBase, relation_data: KafkaProvidesData) -> None:
+    def __init__(self, charm: CharmBase, relation_data: KafkaProviderData) -> None:
         super().__init__(charm, relation_data)
         # Just to keep lint quiet, can't resolve inheritance. The same happened in super().__init__() above
         self.relation_data = relation_data
@@ -2994,15 +3090,15 @@ class KafkaProvidesEventHandlers(EventHandlers):
             )
 
 
-class KafkaProvides(KafkaProvidesData, KafkaProvidesEventHandlers):
+class KafkaProvides(KafkaProviderData, KafkaProviderEventHandlers):
     """Provider-side of the Kafka relation."""
 
     def __init__(self, charm: CharmBase, relation_name: str) -> None:
-        KafkaProvidesData.__init__(self, charm.model, relation_name)
-        KafkaProvidesEventHandlers.__init__(self, charm, self)
+        KafkaProviderData.__init__(self, charm.model, relation_name)
+        KafkaProviderEventHandlers.__init__(self, charm, self)
 
 
-class KafkaRequiresData(RequirerData):
+class KafkaRequirerData(RequirerData):
     """Requirer-side of the Kafka relation."""
 
     def __init__(
@@ -3032,12 +3128,12 @@ class KafkaRequiresData(RequirerData):
         self._topic = value
 
 
-class KafkaRequiresEventHandlers(RequirerEventHandlers):
+class KafkaRequirerEventHandlers(RequirerEventHandlers):
     """Requires-side of the Kafka relation."""
 
     on = KafkaRequiresEvents()  # pyright: ignore [reportAssignmentType]
 
-    def __init__(self, charm: CharmBase, relation_data: KafkaRequiresData) -> None:
+    def __init__(self, charm: CharmBase, relation_data: KafkaRequirerData) -> None:
         super().__init__(charm, relation_data)
         # Just to keep lint quiet, can't resolve inheritance. The same happened in super().__init__() above
         self.relation_data = relation_data
@@ -3050,10 +3146,13 @@ class KafkaRequiresEventHandlers(RequirerEventHandlers):
             return
 
         # Sets topic, extra user roles, and "consumer-group-prefix" in the relation
-        relation_data = {
-            f: getattr(self, f.replace("-", "_"), "")
-            for f in ["consumer-group-prefix", "extra-user-roles", "topic"]
-        }
+        relation_data = {"topic": self.relation_data.topic}
+
+        if self.relation_data.extra_user_roles:
+            relation_data["extra-user-roles"] = self.relation_data.extra_user_roles
+
+        if self.relation_data.consumer_group_prefix:
+            relation_data["consumer-group-prefix"] = self.relation_data.consumer_group_prefix
 
         self.relation_data.update_relation_data(event.relation.id, relation_data)
 
@@ -3096,7 +3195,7 @@ class KafkaRequiresEventHandlers(RequirerEventHandlers):
             return
 
 
-class KafkaRequires(KafkaRequiresData, KafkaRequiresEventHandlers):
+class KafkaRequires(KafkaRequirerData, KafkaRequirerEventHandlers):
     """Provider-side of the Kafka relation."""
 
     def __init__(
@@ -3108,7 +3207,7 @@ class KafkaRequires(KafkaRequiresData, KafkaRequiresEventHandlers):
         consumer_group_prefix: Optional[str] = None,
         additional_secret_fields: Optional[List[str]] = [],
     ) -> None:
-        KafkaRequiresData.__init__(
+        KafkaRequirerData.__init__(
             self,
             charm.model,
             relation_name,
@@ -3117,7 +3216,7 @@ class KafkaRequires(KafkaRequiresData, KafkaRequiresEventHandlers):
             consumer_group_prefix,
             additional_secret_fields,
         )
-        KafkaRequiresEventHandlers.__init__(self, charm, self)
+        KafkaRequirerEventHandlers.__init__(self, charm, self)
 
 
 # Opensearch related events

--- a/tests/integration/dummy-database-charm/src/charm.py
+++ b/tests/integration/dummy-database-charm/src/charm.py
@@ -11,6 +11,7 @@ of the libraries in this repository.
 import logging
 import secrets
 import string
+from typing import Optional
 
 from ops import Relation
 from ops.charm import ActionEvent, CharmBase
@@ -66,7 +67,7 @@ class DatabaseCharm(CharmBase):
         self.framework.observe(self.on.delete_peer_secret_action, self._on_delete_peer_secret)
 
     @property
-    def peer_relation(self) -> Relation | None:
+    def peer_relation(self) -> Optional[Relation]:
         """The cluster peer relation."""
         return self.model.get_relation(PEER)
 

--- a/tests/integration/s3-charm/charmcraft.yaml
+++ b/tests/integration/s3-charm/charmcraft.yaml
@@ -3,6 +3,17 @@
 
 type: charm
 bases:
+  # Whenever "bases" is changed:
+  # - Update tests/integration/conftest.py::pytest_configure()
+  # - Update .github/workflow/ci.yaml integration-test matrix
+  - build-on:
+      - name: "ubuntu"
+        channel: "22.04"
+        architectures: [amd64]
+    run-on:
+      - name: "ubuntu"
+        channel: "22.04"
+        architectures: [amd64]
   - build-on:
       - name: "ubuntu"
         channel: "20.04"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -53,7 +53,11 @@ NUM_APP = 2
 
 @pytest.mark.abort_on_fail
 async def test_deploy_charms(
-    ops_test: OpsTest, application_charm, database_charm, dummy_database_charm
+    ops_test: OpsTest,
+    application_charm,
+    database_charm,
+    dummy_database_charm,
+    dp_libs_ubuntu_series,
 ):
     """Deploy both charms (application and database) to use in the tests."""
     # Deploy both charms (2 units for each application to test that later they correctly
@@ -63,7 +67,7 @@ async def test_deploy_charms(
             application_charm,
             application_name=APPLICATION_APP_NAME,
             num_units=NUM_APP,
-            series="jammy",
+            series=dp_libs_ubuntu_series,
         ),
         ops_test.model.deploy(
             database_charm,
@@ -74,7 +78,7 @@ async def test_deploy_charms(
             },
             application_name=DATABASE_APP_NAME,
             num_units=NUM_DB,
-            series="jammy",
+            series=dp_libs_ubuntu_series,
         ),
         ops_test.model.deploy(
             dummy_database_charm,
@@ -85,7 +89,7 @@ async def test_deploy_charms(
             },
             application_name=DATABASE_DUMMY_APP_NAME,
             num_units=NUM_DUMMY_DB,
-            series="jammy",
+            series=dp_libs_ubuntu_series,
         ),
         ops_test.model.deploy(
             database_charm,
@@ -95,7 +99,7 @@ async def test_deploy_charms(
                 ]
             },
             application_name=ANOTHER_DATABASE_APP_NAME,
-            series="jammy",
+            series=dp_libs_ubuntu_series,
         ),
     )
 

--- a/tests/integration/test_rolling_upgrade.py
+++ b/tests/integration/test_rolling_upgrade.py
@@ -58,11 +58,16 @@ async def upgrade_to_secrets(ops_test, app_name):
 
 
 @pytest.mark.abort_on_fail
-async def test_deploy_charms(ops_test: OpsTest, application_charm, database_charm):
+async def test_deploy_charms(
+    ops_test: OpsTest, application_charm, database_charm, dp_libs_ubuntu_series
+):
     """Deploy both charms (application and database) to use in the tests."""
     await asyncio.gather(
         ops_test.model.deploy(
-            application_charm, application_name=APPLICATION_APP_NAME, num_units=1, series="jammy"
+            application_charm,
+            application_name=APPLICATION_APP_NAME,
+            num_units=1,
+            series=dp_libs_ubuntu_series,
         ),
         ops_test.model.deploy(
             database_charm,
@@ -73,7 +78,7 @@ async def test_deploy_charms(ops_test: OpsTest, application_charm, database_char
             },
             application_name=DATABASE_APP_NAME,
             num_units=1,
-            series="jammy",
+            series=dp_libs_ubuntu_series,
         ),
     )
     await ops_test.model.wait_for_idle(

--- a/tests/integration/test_rolling_upgrade_from_specific_version.py
+++ b/tests/integration/test_rolling_upgrade_from_specific_version.py
@@ -30,7 +30,7 @@ SECRET_REF_PREFIX = "secret-"
 def old_version_to_upgrade_from():
     """Determine how many versions to go back from tox environment (default: previous version)."""
     try:
-        go_backwards = int(os.environ["TOX_ENV"].split("-")[5])
+        go_backwards = int(os.environ["TOX_ENV"].split("-")[-1])
     except TypeError:
         go_backwards = 1
     return LIBPATCH - go_backwards
@@ -41,9 +41,10 @@ async def downgrade_to_old_version(ops_test, app_name):
 
     The data_interfaces module is replaced "on-the-fly" by an older version.
     """
+    version = old_version_to_upgrade_from()
+    logger.info(f"Downgrading {app_name} to version {version}")
     for unit in ops_test.model.applications[app_name].units:
         unit_name_with_dash = unit.name.replace("/", "-")
-        version = old_version_to_upgrade_from()
         complete_command = (
             f"scp tests/integration/data/data_interfaces.py.v{version} "
             f"{unit.name}:/var/lib/juju/agents/unit-{unit_name_with_dash}"
@@ -57,6 +58,7 @@ async def upgrade_to_new_version(ops_test, app_name):
 
     The data_interfaces module is replaced "on-the-fly" by the latest version.
     """
+    logger.info(f"Upgrading {app_name} to latest version")
     for unit in ops_test.model.applications[app_name].units:
         unit_name_with_dash = unit.name.replace("/", "-")
         complete_command = (
@@ -68,11 +70,16 @@ async def upgrade_to_new_version(ops_test, app_name):
 
 @pytest.mark.usefixtures("fetch_old_versions")
 @pytest.mark.abort_on_fail
-async def test_deploy_charms(ops_test: OpsTest, application_charm, database_charm):
+async def test_deploy_charms(
+    ops_test: OpsTest, application_charm, database_charm, dp_libs_ubuntu_series
+):
     """Deploy both charms (application and database) to use in the tests."""
     await asyncio.gather(
         ops_test.model.deploy(
-            application_charm, application_name=APPLICATION_APP_NAME, num_units=1, series="jammy"
+            application_charm,
+            application_name=APPLICATION_APP_NAME,
+            num_units=1,
+            series=dp_libs_ubuntu_series,
         ),
         ops_test.model.deploy(
             database_charm,
@@ -83,7 +90,7 @@ async def test_deploy_charms(ops_test: OpsTest, application_charm, database_char
             },
             application_name=DATABASE_APP_NAME,
             num_units=1,
-            series="jammy",
+            series=dp_libs_ubuntu_series,
         ),
     )
     await ops_test.model.wait_for_idle(

--- a/tests/integration/test_rolling_upgrade_from_specific_version.py
+++ b/tests/integration/test_rolling_upgrade_from_specific_version.py
@@ -60,7 +60,7 @@ async def downgrade_to_old_version(ops_test, app_name):
             f"{unit.name}:/var/lib/juju/agents/unit-{unit_name_with_dash}"
             "/charm/lib/charms/data_platform_libs/v0/data_interfaces.py"
         )
-        ret_code, stdout, y = await ops_test.juju(*complete_command.split())
+        ret_code, stdout, _ = await ops_test.juju(*complete_command.split())
         # scp was successful
         assert not ret_code, f"Couldn't perform copy to {unit.name}."
 
@@ -77,7 +77,7 @@ async def upgrade_to_new_version(ops_test, app_name):
             "scp lib/charms/data_platform_libs/v0/data_interfaces.py "
             f"{unit.name}:/var/lib/juju/agents/unit-{unit_name_with_dash}/charm/lib/charms/data_platform_libs/v0/"
         )
-        ret_code, stdout, y = await ops_test.juju(*complete_command.split())
+        ret_code, stdout, _ = await ops_test.juju(*complete_command.split())
         # scp was successful
         assert not ret_code, f"Couldn't perform copy to {unit.name}."
 

--- a/tests/integration/test_s3_charm.py
+++ b/tests/integration/test_s3_charm.py
@@ -19,7 +19,9 @@ SECOND_S3_RELATION_NAME = "second-s3-credentials"
 
 
 @pytest.mark.abort_on_fail
-async def test_deploy_charms(ops_test: OpsTest, application_s3_charm, s3_charm):
+async def test_deploy_charms(
+    ops_test: OpsTest, application_s3_charm, s3_charm, dp_libs_ubuntu_series
+):
     """Deploy both charms (application and s3 provider app) to use in the tests."""
     # Deploy both charms (2 units for each application to test that later they correctly
     # set data in the relation application databag using only the leader unit).
@@ -28,7 +30,7 @@ async def test_deploy_charms(ops_test: OpsTest, application_s3_charm, s3_charm):
             application_s3_charm,
             application_name=APPLICATION_APP_NAME,
             num_units=2,
-            series="jammy",
+            series=dp_libs_ubuntu_series,
         ),
         ops_test.model.deploy(s3_charm, application_name=S3_APP_NAME, num_units=2, series="jammy"),
     )

--- a/tox.ini
+++ b/tox.ini
@@ -78,7 +78,7 @@ commands =
         -m pytest -v --tb native -s {posargs} {[vars]tests_path}/unit
     coverage report
 
-[testenv:integration-database]
+[testenv:integration-db]
 description = Run database integration tests
 deps =
     psycopg2-binary
@@ -90,7 +90,7 @@ deps =
 commands =
     pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/test_charm.py
 
-[testenv:integration-upgrades-databag-to-secrets]
+[testenv:integration-upgrade-databag]
 description = Run database integration tests
 deps =
     psycopg2-binary
@@ -102,7 +102,7 @@ deps =
 commands =
     pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/test_rolling_upgrade.py
 
-[testenv:integration-interfaces-upgrade-from-version-{1,2,3,4}-earlier]
+[testenv:integration-upgrade-{1,2,3,4,5,6,7}]
 description = Run database integration tests
 deps =
     psycopg2-binary


### PR DESCRIPTION
The libs [are supporting](https://chat.canonical.com/canonical/pl/isjm3to6dtrsdpe1pduuk56wpr) two Ubuntu versions
 - focal
 - jammy
 
Together with a number of Juju versions
 - 2.9/stable
 - 3.1/stable
 - 3.2/stable
 - 3.3/stable
 - 3.4/stable
 - 3.5/stable

The pipelines should be reflecting that ;-)

See the documentation added in the CONTRIBUTING document regarding the cross-OS testing.

Note: We are actually using the same mechanism as `mysql-router-operator`. We should be moving to the new re-usable 
workflows when together with that charm -- once the parametrization required may be supported.