### PR TITLE
[DPE-4772] Subordinate scale up

### DIFF
--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -2842,6 +2842,22 @@ class DatabaseRequirerEventHandlers(RequirerEventHandlers):
 
     def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
         """Event emitted when the database relation has changed."""
+        remote_units = [
+            key
+            for key in event.relation.data.keys()
+            if isinstance(key, Unit) and key.name.startswith(event.relation.app.name)
+        ]
+        # Check that provider units have joined.
+        if len(remote_units) == 0:
+            logger.debug("No provider units are available.")
+            return
+        elif (
+            len(remote_units) == 1
+            and event.relation.data[remote_units[0]].get("state", "ready") != "ready"
+        ):
+            logger.debug("Subordinate provider unit not ready.")
+            return
+
         # Check which data has changed to emit customs events.
         diff = self._diff(event)
 

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -331,7 +331,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 37
+LIBPATCH = 38
 
 PYDEPS = ["ops>=2.0.0"]
 

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -2855,7 +2855,7 @@ class DatabaseRequirerEventHandlers(RequirerEventHandlers):
         is_subordinate = False
         remote_unit_data = None
         for key in event.relation.data.keys():
-            if isinstance(key, Unit) and key.name.startswith(self.charm.app.name):
+            if isinstance(key, Unit) and not key.name.startswith(self.charm.app.name):
                 remote_unit_data = event.relation.data[key]
             elif isinstance(key, Application) and key.name != self.charm.app.name:
                 is_subordinate = event.relation.data[key].get("subordinated") == "true"


### PR DESCRIPTION
Scaling up subordinate charms with a single endpoint is error prone by default, since the endpoint is local, but a new unit may not yet be ready to serve when the new consumer receives a `database_created` event. The PR adds a check to the unit relation databag for a `state` value that can be used to synchronise the emission of events and `subordinated` flag in the provider application databag. The change should be backwards compatible.

PR https://github.com/canonical/pgbouncer-operator/pull/274 implements the other side of the synchronisation.