### PR TITLE
[DPE-5306][SECURITY] No write before protocol init

### DIFF
--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -1457,7 +1457,7 @@ class EventHandlers(Object):
 class ProviderData(Data):
     """Base provides-side of the data products relation."""
 
-    DATABASE_FIELD = "database"
+    RESOURCE_FIELD = "database"
 
     def __init__(
         self,
@@ -1626,7 +1626,7 @@ class ProviderData(Data):
         req_secret_fields = []
 
         keys = set(data.keys())
-        if self.fetch_relation_field(relation.id, self.DATABASE_FIELD) is None and (
+        if self.fetch_relation_field(relation.id, self.RESOURCE_FIELD) is None and (
             keys - {"endpoints", "read-only-endpoints", "replset"}
         ):
             raise PrematureDataAccessError(
@@ -3305,7 +3305,7 @@ class KafkaRequiresEvents(CharmEvents):
 class KafkaProviderData(ProviderData):
     """Provider-side of the Kafka relation."""
 
-    DATABASE_FIELD = "topic"
+    RESOURCE_FIELD = "topic"
 
     def __init__(self, model: Model, relation_name: str) -> None:
         super().__init__(model, relation_name)
@@ -3556,7 +3556,7 @@ class OpenSearchRequiresEvents(CharmEvents):
 class OpenSearchProvidesData(ProviderData):
     """Provider-side of the OpenSearch relation."""
 
-    DATABASE_FIELD = "index"
+    RESOURCE_FIELD = "index"
 
     def __init__(self, model: Model, relation_name: str) -> None:
         super().__init__(model, relation_name)

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -1625,8 +1625,9 @@ class ProviderData(Data):
         """Set values for fields not caring whether it's a secret or not."""
         req_secret_fields = []
 
-        if self.fetch_relation_field(relation.id, self.DATABASE_FIELD) is None and not (
-            len(data.keys()) == 1 and "endpoints" in data
+        keys = set(data.keys())
+        if self.fetch_relation_field(relation.id, self.DATABASE_FIELD) is None and (
+            keys - {"endpoints", "read-only-endpoints", "replset"}
         ):
             raise PrematureDataAccessError(
                 "Premature access to relation data, update is forbidden before the connection is initialized."

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -189,7 +189,7 @@ def fetch_old_versions():
     for commit in last_commits:
         check_call(f"git checkout {commit}", shell=True)
         version = check_output(
-            "grep LIBPATCH lib/charms/data_platform_libs/v0/data_interfaces.py | cut -d ' ' -f 3",
+            "grep ^LIBPATCH lib/charms/data_platform_libs/v0/data_interfaces.py | cut -d ' ' -f 3",
             shell=True,
             universal_newlines=True,
         )

--- a/tests/unit/test_data_interfaces.py
+++ b/tests/unit/test_data_interfaces.py
@@ -433,7 +433,14 @@ class DataProvidesBaseTests(ABC):
 
         # Interface function: fetch_relation_field()
         interface.update_relation_data(self.rel_id, {"endpoints": "host1:port1"})
+        interface.update_relation_data(self.rel_id, {"read-only-endpoints": "host2:port2"})
+        interface.update_relation_data(self.rel_id, {"replset": "mongo-replset"})
+
         assert interface.fetch_my_relation_field(self.rel_id, "endpoints") == "host1:port1"
+        assert (
+            interface.fetch_my_relation_field(self.rel_id, "read-only-endpoints") == "host2:port2"
+        )
+        assert interface.fetch_my_relation_field(self.rel_id, "replset") == "mongo-replset"
 
     @pytest.mark.usefixtures("only_without_juju_secrets")
     def test_set_credentials(self):


### PR DESCRIPTION
# Issue

https://github.com/canonical/data-platform-libs/issues/193

In case any write operation may take place before the protocol is established the `Provider` may not yet be aware whether secrets are to be used or not. Thus, the write operation may end up as plain text in the databag, instead of secrets.

Example:

A charm may receive TLS certs anytime, that are to be shared on a client relation.
When the charm got the TLS secrest, it just "blindly" writes them using `update_relation_data()` on `update-status` or `certificate-available` or so.
Which technically could be executed BEFORE the  `Requirer` (!!!!) `relation-created` handler would put the `requested-secrets` list -- highlighting that TLS certs are stored as a Juju Secret on this relation.

# Solution

No `Provider` write operation is allowed before the initial part of the protocol is finished. 

This can be assured by waiting until the `Requirer` would add the `database` field to the Relation Data. By this time the `Requirer` must have executed its `relation-created` hook (where `requested-secrets` is written to the databag)

NOTE: Given that the change is straightforward, while the scenario is non-trivial to reproduce. I believe that unittest coverage is sufficient.


NOTE2: This may be a **breaking change** for charms that were publishing sensitive data premature. Clearly corresponding charm code is to be fixed.

See PG corresponding fix with healthy pipelines: https://github.com/canonical/postgresql-operator/pull/615

