### PR TITLE
[MISC] Disable destructive mode

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,4 +50,5 @@ jobs:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}" # FIXME: current token will expire in 2025-04-16
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "${{ steps.channel.outputs.name }}"
+          destructive-mode: false
 


### PR DESCRIPTION
Charm release fails due to enabled destructive mode and trying to build 22.04 charm on 24.04

The failure on release is https://github.com/canonical/data-platform-libs/actions/runs/13115477658/job/36589968827#step:5:16