### PR TITLE
[DPE-6457]: Implement feedback from etcd interface implementation

### DIFF
--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -331,7 +331,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 43
+LIBPATCH = 44
 
 PYDEPS = ["ops>=2.0.0"]
 

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -3846,7 +3846,7 @@ class EtcdProviderEvent(RelationEventWithSecret):
 
     @property
     def mtls_cert(self) -> Optional[str]:
-        """Returns TLS chain of the client."""
+        """Returns TLS cert of the client."""
         if not self.relation.app:
             return None
 
@@ -3861,7 +3861,7 @@ class EtcdProviderEvent(RelationEventWithSecret):
                 return content.get("mtls-cert")
 
 
-class MTLSChainUpdatedEvent(EtcdProviderEvent):
+class MTLSCertUpdatedEvent(EtcdProviderEvent):
     """Event emitted when the mtls relation is updated."""
 
     def __init__(self, handle, relation, old_mtls_cert: Optional[str] = None, app=None, unit=None):
@@ -3885,7 +3885,7 @@ class EtcdProviderEvents(CharmEvents):
     This class defines the events that Etcd can emit.
     """
 
-    mtls_cert_updated = EventSource(MTLSChainUpdatedEvent)
+    mtls_cert_updated = EventSource(MTLSCertUpdatedEvent)
 
 
 class EtcdRequirerEvent(DatabaseRequiresEvent):
@@ -4022,11 +4022,11 @@ class EtcdRequirerData(RequirerData):
         self.mtls_cert = mtls_cert
 
     def set_mtls_cert(self, relation_id: int, mtls_cert: str) -> None:
-        """Set the mtls chain in the application relation databag / secret.
+        """Set the mtls cert in the application relation databag / secret.
 
         Args:
             relation_id: the identifier for a particular relation.
-            mtls_cert: mtls chain.
+            mtls_cert: mtls cert.
         """
         self.update_relation_data(relation_id, {"mtls-cert": mtls_cert})
 

--- a/tests/unit/test_data_interfaces.py
+++ b/tests/unit/test_data_interfaces.py
@@ -18,8 +18,8 @@ from ops.testing import Harness
 from parameterized import parameterized
 
 from charms.data_platform_libs.v0.data_interfaces import (
+    PROV_SECRET_FIELDS,
     PROV_SECRET_PREFIX,
-    PROVIDED_SECRET_FIELDS,
     REQ_SECRET_FIELDS,
     DatabaseCreatedEvent,
     DatabaseEndpointsChangedEvent,
@@ -603,7 +603,7 @@ class TestDatabaseProvides(DataProvidesBaseTests, unittest.TestCase):
         interface.update_relation_data(relation_id, {"secret-field": "bla"})
         interface.update_relation_data(relation_id, {"mysecret1@mygroup": "bla"})
 
-        assert set(interface.secret_fields) == {
+        assert set(interface.local_secret_fields) == {
             f"secret-field-{scope}",
             "secret-field",
             "mysecret1@mygroup",
@@ -2256,7 +2256,7 @@ class TestDatabaseRequires(DataRequirerBaseTests, unittest.TestCase):
                 "database": "data_platform",
                 "extra-user-roles": "CREATEDB,CREATEROLE",
                 REQ_SECRET_FIELDS: json.dumps(self.harness.charm.requirer.remote_secret_fields),
-                PROVIDED_SECRET_FIELDS: json.dumps(self.harness.charm.requirer.secret_fields),
+                PROV_SECRET_FIELDS: json.dumps(self.harness.charm.requirer.local_secret_fields),
             }
         }
 

--- a/tests/unit/test_data_interfaces.py
+++ b/tests/unit/test_data_interfaces.py
@@ -1971,7 +1971,7 @@ class TestDatabaseRequires(DataRequirerBaseTests, unittest.TestCase):
                 "database": "data_platform",
                 "extra-user-roles": "CREATEDB,CREATEROLE",
                 "requested-secrets": json.dumps(SECRET_FIELDS),
-                "provided-secrets": '["mtls-chain"]',
+                "provided-secrets": '["mtls-cert"]',
             }
         }
 
@@ -2000,7 +2000,7 @@ class TestDatabaseRequires(DataRequirerBaseTests, unittest.TestCase):
             "database": "data_platform",
             "extra-user-roles": "CREATEDB,CREATEROLE",
             "requested-secrets": json.dumps(SECRET_FIELDS),
-            "provided-secrets": '["mtls-chain"]',
+            "provided-secrets": '["mtls-cert"]',
         }
 
         # Non-leader can try to fetch data (won't have anything thought, as only app data is there...


### PR DESCRIPTION
This pull request includes several changes to the `lib/charms/data_platform_libs/v0/data_interfaces.py` file, focusing on renaming variables for clarity and updating secret fields handling. The most important changes include renaming `_secret_fields` to `_local_secret_fields`, updating the handling of provided and requested secrets, and modifying the secret group mapping.

### Variable Renaming:
* Renamed `_secret_fields` to `_local_secret_fields` throughout the file for better clarity and consistency. [[1]](diffhunk://#diff-7bc59790c534f66e8e6a800e826efade12b1320cfe3b37b4fdc9a41ca0b0a6dfL986-L989) [[2]](diffhunk://#diff-7bc59790c534f66e8e6a800e826efade12b1320cfe3b37b4fdc9a41ca0b0a6dfL1013-R1014) [[3]](diffhunk://#diff-7bc59790c534f66e8e6a800e826efade12b1320cfe3b37b4fdc9a41ca0b0a6dfL1718-L1720) [[4]](diffhunk://#diff-7bc59790c534f66e8e6a800e826efade12b1320cfe3b37b4fdc9a41ca0b0a6dfL1798-L1803)

### Secret Fields Handling:
* Updated the handling of provided and requested secrets by renaming `PROVIDED_SECRET_FIELDS` to `PROV_SECRET_FIELDS` and ensuring consistent usage across methods. [[1]](diffhunk://#diff-7bc59790c534f66e8e6a800e826efade12b1320cfe3b37b4fdc9a41ca0b0a6dfR354-L355) [[2]](diffhunk://#diff-7bc59790c534f66e8e6a800e826efade12b1320cfe3b37b4fdc9a41ca0b0a6dfL1774-R1773) [[3]](diffhunk://#diff-7bc59790c534f66e8e6a800e826efade12b1320cfe3b37b4fdc9a41ca0b0a6dfL1861-R1862)
* Modified methods to use `_local_secret_fields` instead of `_secret_fields` and adjusted logic accordingly. [[1]](diffhunk://#diff-7bc59790c534f66e8e6a800e826efade12b1320cfe3b37b4fdc9a41ca0b0a6dfL1030-R1028) [[2]](diffhunk://#diff-7bc59790c534f66e8e6a800e826efade12b1320cfe3b37b4fdc9a41ca0b0a6dfL1086-R1084) [[3]](diffhunk://#diff-7bc59790c534f66e8e6a800e826efade12b1320cfe3b37b4fdc9a41ca0b0a6dfL1097-R1095) [[4]](diffhunk://#diff-7bc59790c534f66e8e6a800e826efade12b1320cfe3b37b4fdc9a41ca0b0a6dfL1220-R1218) [[5]](diffhunk://#diff-7bc59790c534f66e8e6a800e826efade12b1320cfe3b37b4fdc9a41ca0b0a6dfL1927-R1925)

### Secret Group Mapping:
* Changed the secret group mapping field from `mtls-chain` to `mtls-cert` to better reflect its purpose. [[1]](diffhunk://#diff-7bc59790c534f66e8e6a800e826efade12b1320cfe3b37b4fdc9a41ca0b0a6dfL968-R968) [[2]](diffhunk://#diff-7bc59790c534f66e8e6a800e826efade12b1320cfe3b37b4fdc9a41ca0b0a6dfL3855-R3849)

These changes aim to improve code readability and maintainability by making variable names more descriptive and ensuring consistent handling of secret fields.