### PR TITLE
[MISC] Fix data-models v1 LIBPATCH

### DIFF
--- a/lib/charms/data_platform_libs/v1/data_models.py
+++ b/lib/charms/data_platform_libs/v1/data_models.py
@@ -168,7 +168,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 0
 
 PYDEPS = ["ops>=2.0.0", "pydantic>=2,<3"]
 


### PR DESCRIPTION
This PR fixes the `LIBPATCH` stated in the recently merged Data-models v1 [PR](https://github.com/canonical/data-platform-libs/pull/201), to unblock its publication.

---

Adding reviewers according to this Cross-team components maintainers [page](https://canonical-data.readthedocs-hosted.com/products/cross-team/).