### PR TITLE
[DPE-7365] feat: add mtls-cert to kafka_client

### DIFF
--- a/tests/v0/integration/application-charm/actions.yaml
+++ b/tests/v0/integration/application-charm/actions.yaml
@@ -40,3 +40,7 @@ delete-relation-field:
   field:
     type: string
     description: Relation field
+
+set-mtls-cert:
+  description: Sets the MTLS cert for the requirer application.
+ 


### PR DESCRIPTION
This PR adds `mtls-cert` field to `kafka_client` relations, compliant with DA150. This change is backwards-compatible since the field is optional and it also doesn't break clients which rely on positional args.