### PR TITLE
Fix missing impl. of _on_secrets_changed abstract method

### DIFF
--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -331,7 +331,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 47
+LIBPATCH = 48
 
 PYDEPS = ["ops>=2.0.0"]
 
@@ -3759,6 +3759,10 @@ class OpenSearchProvidesEventHandlers(ProviderEventHandlers):
             getattr(self.on, "index_requested").emit(
                 event.relation, app=event.app, unit=event.unit
             )
+
+    def _on_secret_changed_event(self, event: SecretChangedEvent) -> None:
+        """Event emitted when the relation data has changed."""
+        pass
 
 
 class OpenSearchProvides(OpenSearchProvidesData, OpenSearchProvidesEventHandlers):


### PR DESCRIPTION
This PR aims at fixing the error occurring [here](https://github.com/canonical/opensearch-operator/actions/runs/15680439683/job/44170961194?pr=655#step:8:20795) - for opensearch:
```
File "/var/lib/juju/agents/unit-opensearch-1/charm/lib/charms/data_platform_libs/v0/data_interfaces.py", line 1673, in _on_secret_changed_event
    raise NotImplementedError
```