### PR TITLE
fix: pin opentelemtry in s3 test charms

### DIFF
--- a/tests/v0/integration/application-s3-charm/charmcraft.yaml
+++ b/tests/v0/integration/application-s3-charm/charmcraft.yaml
@@ -21,4 +21,4 @@ bases:
 parts:
   charm:
     charm-binary-python-packages:
-      - opentelemetry-api
+      - opentelemetry-api==1.33.1

--- a/tests/v0/integration/s3-charm/charmcraft.yaml
+++ b/tests/v0/integration/s3-charm/charmcraft.yaml
@@ -25,4 +25,4 @@ bases:
 parts:
   charm:
     charm-binary-python-packages:
-      - opentelemetry-api
+      - opentelemetry-api==1.33.1


### PR DESCRIPTION
This PR fixes s3 test charm issues happening recently in CI: https://github.com/canonical/data-platform-libs/actions/runs/15721618065/job/44303503532

`opentelemetry-api` 1.34 is not compatible with the current tooling.