### PR TITLE
fix: bump changed libs LIBPATCH

### DIFF
--- a/lib/charms/data_platform_libs/v0/database_provides.py
+++ b/lib/charms/data_platform_libs/v0/database_provides.py
@@ -80,7 +80,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 logger = logging.getLogger(__name__)
 

--- a/lib/charms/data_platform_libs/v0/database_requires.py
+++ b/lib/charms/data_platform_libs/v0/database_requires.py
@@ -160,7 +160,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version.
-LIBPATCH = 6
+LIBPATCH = 7
 
 logger = logging.getLogger(__name__)
 

--- a/lib/charms/data_platform_libs/v0/s3.py
+++ b/lib/charms/data_platform_libs/v0/s3.py
@@ -137,7 +137,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 logger = logging.getLogger(__name__)
 

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -285,7 +285,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 18
+LIBPATCH = 19
 
 PYDEPS = ["pydantic>=1.10,<2", "poetry-core"]
 


### PR DESCRIPTION
This PR fixes an issue caused by [this PR](https://github.com/canonical/data-platform-libs/pull/134/files#diff-a01d43dd46de468e0afbd31ac8efced74720d6cbaf7c62c6f68b71d0066aef6c), which didn't update the LIBPATCH on some libs, causing the whole release CI to abort in the new `noctua`-based workflow

https://github.com/canonical/data-platform-libs/actions/runs/15726984751/job/44333862654




