### PR TITLE
[MISC] Bump patch back

### DIFF
--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -285,7 +285,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 18
+LIBPATCH = 19
 
 PYDEPS = ["pydantic>=1.10,<2", "poetry-core"]
 


### PR DESCRIPTION
Editor's linter changed the content: https://github.com/canonical/data-platform-libs/commit/132f11144e82eed7af71476e9bd9fe72536dcc14#diff-a01d43dd46de468e0afbd31ac8efced74720d6cbaf7c62c6f68b71d0066aef6cL932

So the patch now needs to be 19. Sorry for the noise.