### PR TITLE
[MISC] Revert s3 libpatch

### DIFF
--- a/lib/charms/data_platform_libs/v0/s3.py
+++ b/lib/charms/data_platform_libs/v0/s3.py
@@ -137,7 +137,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 5
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Charmcraft fetch-lib claims everything except data_interfaces (which should bee released) is up to date:
```
Library charms.data_platform_libs.v0.data_interfaces has local changes, cannot be updated.
Library charms.data_platform_libs.v0.data_models was already up to date in version 0.5
Library charms.data_platform_libs.v0.data_secrets was already up to date in version 0.3.
Library charms.data_platform_libs.v0.database_provides was already up to date in version 0.5.
Library charms.data_platform_libs.v0.database_requires was already up to date in version 0.7.
Library charms.data_platform_libs.v0.s3 was already up to date in version 0.5.
Library charms.data_platform_libs.v0.upgrade was already up to date in version 0.19.
Library charms.data_platform_libs.v1.data_models was already up to date in version 1.0
Library charms.harness_extensions.v0.capture_events was already up to date in version 0.3.
```