### PR TITLE
other: bump version

### DIFF
--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -331,7 +331,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 48
+LIBPATCH = 49
 
 PYDEPS = ["ops>=2.0.0"]
 

--- a/tests/v0/integration/dummy-database-charm/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/tests/v0/integration/dummy-database-charm/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -331,7 +331,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 48
+LIBPATCH = 49
 
 PYDEPS = ["ops>=2.0.0"]
 


### PR DESCRIPTION
This pull request bumps the version after the bump of https://github.com/canonical/data-platform-libs/pull/223 was made ineffective by parallel bumps.