### PR TITLE
chore: pin ops to <3 and pytest-operator to <0.43

### DIFF
--- a/requirements/v0/requirements.txt
+++ b/requirements/v0/requirements.txt
@@ -1,3 +1,3 @@
-ops >= 2.1.1
+ops >= 2.1.1,<3
 pydantic>=1.10,<2
 poetry-core

--- a/tox.ini
+++ b/tox.ini
@@ -88,7 +88,7 @@ deps =
     psycopg2-binary
     pytest<8.2.0
     juju{env:LIBJUJU_VERSION_SPECIFIER:==3.6.1.0}
-    pytest-operator
+    pytest-operator<0.43
     pytest-mock
     websockets{env:WEBSOCKETS_VERSION_SPECIFIER:}
     -r {[vars]reqs_path}/v0/requirements.txt
@@ -101,7 +101,7 @@ deps =
     psycopg2-binary
     pytest<8.2.0
     juju{env:LIBJUJU_VERSION_SPECIFIER:==3.6.1.0}
-    pytest-operator
+    pytest-operator<0.43
     pytest-mock
     websockets{env:WEBSOCKETS_VERSION_SPECIFIER:}
     -r {[vars]reqs_path}/v0/requirements.txt
@@ -114,7 +114,7 @@ deps =
     psycopg2-binary
     pytest<8.2.0
     juju{env:LIBJUJU_VERSION_SPECIFIER:==3.6.1.0}
-    pytest-operator
+    pytest-operator<0.43
     pytest-mock
     websockets{env:WEBSOCKETS_VERSION_SPECIFIER:}
     -r {[vars]reqs_path}/v0/requirements.txt
@@ -129,7 +129,7 @@ deps =
     psycopg2-binary
     pytest<8.2.0
     juju{env:LIBJUJU_VERSION_SPECIFIER:==3.6.1.0}
-    pytest-operator
+    pytest-operator<0.43
     pytest-mock
     websockets{env:WEBSOCKETS_VERSION_SPECIFIER:}
     -r {[vars]reqs_path}/v0/requirements.txt
@@ -142,7 +142,7 @@ deps =
     psycopg2-binary
     pytest<8.2.0
     juju{env:LIBJUJU_VERSION_SPECIFIER:==3.6.1.0}
-    pytest-operator
+    pytest-operator<0.43
     pytest-mock
     websockets{env:WEBSOCKETS_VERSION_SPECIFIER:}
     -r {[vars]reqs_path}/v0/requirements.txt
@@ -155,7 +155,7 @@ deps =
     psycopg2-binary
     pytest<8.2.0
     juju{env:LIBJUJU_VERSION_SPECIFIER:==3.6.1.0}
-    pytest-operator
+    pytest-operator<0.43
     pytest-mock
     websockets{env:WEBSOCKETS_VERSION_SPECIFIER:}
     -r {[vars]reqs_path}/v0/requirements.txt
@@ -167,7 +167,7 @@ description = Run secrets integration tests
 deps =
     pytest<8.2.0
     juju{env:LIBJUJU_VERSION_SPECIFIER:==3.6.1.0}
-    pytest-operator
+    pytest-operator<0.43
     pytest-mock
     websockets{env:WEBSOCKETS_VERSION_SPECIFIER:}
     -r {[vars]reqs_path}/v0/requirements.txt


### PR DESCRIPTION
Apparently, they switched to `uv` for builds in `pytest-operator` [v0.43](https://github.com/charmed-kubernetes/pytest-operator/pull/148/files#diff-84321598744d84dbee2318e634c74c9aae39a1c253f1c4bd17ebf9ef2f807b11) and that has broken things in our CI.

This PR pins `ops` to `<3` and `pytest-operator` to `<0.43`