### PR TITLE
ci: pin websocket-client to <1.9.0 in s3 test charm

### DIFF
--- a/tests/v0/integration/s3-charm/requirements.txt
+++ b/tests/v0/integration/s3-charm/requirements.txt
@@ -1,1 +1,2 @@
 ops >= 2.0.0, < 3.0.0
+websocket-client < 1.9.0


### PR DESCRIPTION
This PR fixes the [CI issue with the s3 test application charm](https://github.com/canonical/data-platform-libs/actions/runs/18669757675), `websocket-client 1.9.0` is incompatible with our version of Python. 