### PR TITLE
fix: Don't listen to secret changed of other rels

### DIFF
--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -4276,7 +4276,7 @@ class KafkaProviderEventHandlers(ProviderEventHandlers):
             logging.info("Secret changed event ignored for Secret Owner")
 
         if relation.name != self.relation_data.relation_name:
-            logger.info(
+            logger.debug(
                 "Ignoring secret-changed from endpoint %s (expected %s)",
                 relation.name,
                 self.relation_data.relation_name,
@@ -5310,7 +5310,7 @@ class OpenSearchRequiresEventHandlers(RequirerEventHandlers):
             return
 
         if relation.name != self.relation_data.relation_name:
-            logger.info(
+            logger.debug(
                 "Ignoring secret-changed from endpoint %s (expected %s)",
                 relation.name,
                 self.relation_data.relation_name,
@@ -5580,7 +5580,7 @@ class EtcdProviderEventHandlers(ProviderEventHandlers):
             return
 
         if relation.name != self.relation_data.relation_name:
-            logger.info(
+            logger.debug(
                 "Ignoring secret-changed from endpoint %s (expected %s)",
                 relation.name,
                 self.relation_data.relation_name,
@@ -5733,7 +5733,7 @@ class EtcdRequirerEventHandlers(RequirerEventHandlers):
             logging.info("Secret changed event ignored for Secret Owner")
 
         if relation.name != self.relation_data.relation_name:
-            logger.info(
+            logger.debug(
                 "Ignoring secret-changed from endpoint %s (expected %s)",
                 relation.name,
                 self.relation_data.relation_name,

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -453,7 +453,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 57
+LIBPATCH = 58
 
 PYDEPS = ["ops>=2.0.0"]
 
@@ -5301,6 +5301,14 @@ class OpenSearchRequiresEventHandlers(RequirerEventHandlers):
             )
             return
 
+        if relation.name != self.relation_data.relation_name:
+            logger.info(
+                "Ignoring secret-changed from endpoint %s (expected %s)",
+                relation.name,
+                self.relation_data.relation_name,
+            )
+            return
+
         if relation.app == self.charm.app:
             logging.info("Secret changed event ignored for Secret Owner")
 
@@ -5707,6 +5715,14 @@ class EtcdRequirerEventHandlers(RequirerEventHandlers):
 
         if relation.app == self.charm.app:
             logging.info("Secret changed event ignored for Secret Owner")
+
+        if relation.name != self.relation_data.relation_name:
+            logger.info(
+                "Ignoring secret-changed from endpoint %s (expected %s)",
+                relation.name,
+                self.relation_data.relation_name,
+            )
+            return
 
         remote_unit = None
         for unit in relation.units:

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -4275,6 +4275,14 @@ class KafkaProviderEventHandlers(ProviderEventHandlers):
         if relation.app == self.charm.app:
             logging.info("Secret changed event ignored for Secret Owner")
 
+        if relation.name != self.relation_data.relation_name:
+            logger.info(
+                "Ignoring secret-changed from endpoint %s (expected %s)",
+                relation.name,
+                self.relation_data.relation_name,
+            )
+            return
+
         remote_unit = None
         for unit in relation.units:
             if unit.app != self.charm.app:
@@ -5568,6 +5576,14 @@ class EtcdProviderEventHandlers(ProviderEventHandlers):
         if not relation:
             logging.info(
                 f"Received secret {event.secret.label} but couldn't parse, seems irrelevant"
+            )
+            return
+
+        if relation.name != self.relation_data.relation_name:
+            logger.info(
+                "Ignoring secret-changed from endpoint %s (expected %s)",
+                relation.name,
+                self.relation_data.relation_name,
             )
             return
 


### PR DESCRIPTION
## Issue

The secret changed event handlers are a bit too eager to handle secret changed events.
They should beware to handle only the events for the relations they are monitoring.

##

This commit enforces that on Data interfaces v0.
It works by checking the relation name computed from the secret with the relation name of the relation that we are monitoring.
If they are different, exit early and let the correct handler handle that event.