### PR TITLE
Add 'upgrade' library v1

### DIFF
--- a/lib/charms/data_platform_libs/v1/upgrade.py
+++ b/lib/charms/data_platform_libs/v1/upgrade.py
@@ -1,0 +1,1091 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""Library to manage in-place upgrades for charms running on VMs and K8s.
+
+This library contains handlers for `upgrade` relation events used to coordinate
+between units in an application during a `juju refresh`, as well as `Pydantic` models
+for instantiating, validating and comparing dependencies.
+
+An upgrade on VMs is initiated with the command `juju refresh`. Once executed, the following
+events are emitted to each unit at random:
+    - `upgrade-charm`
+    - `config-changed`
+    - `leader-settings-changed` - Non-leader only
+
+Charm authors can implement the classes defined in this library to streamline the process of
+coordinating which unit updates when, achieved through updating of unit-data `state` throughout.
+
+At a high-level, the upgrade steps are as follows:
+    - Run pre-checks on the cluster to confirm it is safe to upgrade
+    - Create stack of unit.ids, to serve as the upgrade order (generally workload leader is last)
+    - Start the upgrade by issuing a Juju CLI command
+    - The unit at the top of the stack gets permission to upgrade
+    - The unit handles the upgrade and restarts their service
+    - Repeat, until all units have restarted
+
+### Usage by charm authors
+
+#### `upgrade` relation
+
+Charm authors must implement an additional peer-relation.
+
+As this library uses relation data exchanged between units to coordinate, charm authors
+need to add a new relation interface. The relation name does not matter.
+
+`metadata.yaml`
+```yaml
+peers:
+  upgrade:
+    interface: upgrade
+```
+
+#### Dependencies JSON/Dict
+
+Charm authors must implement a dict object tracking current charm versions, requirements + upgradability.
+
+Many workload versions may be incompatible with older/newer versions. This same idea also can apply to
+charm or snap versions. Workloads with required related applications (e.g Kafka + ZooKeeper) also need to
+ensure their versions are compatible during an upgrade, to avoid cluster failure.
+
+As such, it is necessasry to freeze any dependencies within each published charm. An example of this could
+be creating a `DEPENDENCIES` dict within the charm code, with the following structure:
+
+`src/literals.py`
+```python
+DEPENDENCIES = {
+    "kafka_charm": {
+        "dependencies": {"zookeeper": ">50"},
+        "name": "kafka",
+        "upgrade_supported": ">90",
+        "version": "100",
+    },
+    "kafka_service": {
+        "dependencies": {"zookeeper": "^3"},
+        "name": "kafka",
+        "upgrade_supported": ">=0.8",
+        "version": "3.3.2",
+    },
+}
+```
+
+The first-level key names are arbitrary labels for tracking what those versions+dependencies are for.
+The `dependencies` second-level values are a key-value map of any required external applications,
+    and the versions this packaged charm can support.
+The `upgrade_suppported` second-level values are requirements from which an in-place upgrade can be
+    supported by the charm.
+The `version` second-level values correspond to the current version of this packaged charm.
+
+Any requirements comply with [`poetry`'s dependency specifications](https://python-poetry.org/docs/dependency-specification/#caret-requirements).
+
+### Dependency Model
+
+Charm authors must implement their own class inheriting from `DependencyModel`.
+
+Using a `Pydantic` model to instantiate the aforementioned `DEPENDENCIES` dict gives stronger type safety and additional
+layers of validation.
+
+Implementation just needs to ensure that the top-level key names from `DEPENDENCIES` are defined as attributed in the model.
+
+`src/upgrade.py`
+```python
+from pydantic import BaseModel
+
+class KafkaDependenciesModel(BaseModel):
+    kafka_charm: DependencyModel
+    kafka_service: DependencyModel
+```
+
+### Overrides for `DataUpgrade`
+
+Charm authors must define their own class, inheriting from `DataUpgrade`, overriding all required `abstractmethod`s.
+
+```python
+class ZooKeeperUpgrade(DataUpgrade):
+    def __init__(self, charm: "ZooKeeperUpgrade", **kwargs):
+        super().__init__(charm, **kwargs)
+        self.charm = charm
+```
+
+#### Implementation of `pre_upgrade_check()`
+
+Before upgrading a cluster, it's a good idea to check that it is stable and healthy before permitting it.
+Here, charm authors can validate upgrade safety through API calls, relation-data checks, etc.
+If any of these checks fail, raise `ClusterNotReadyError`.
+
+```python
+    @override
+    def pre_upgrade_check(self) -> None:
+        default_message = "Pre-upgrade check failed and cannot safely upgrade"
+        try:
+            if not self.client.members_broadcasting or not len(self.client.server_members) == len(
+                self.charm.cluster.peer_units
+            ):
+                raise ClusterNotReadyError(
+                    message=default_message,
+                    cause="Not all application units are connected and broadcasting in the quorum",
+                )
+
+            if self.client.members_syncing:
+                raise ClusterNotReadyError(
+                    message=default_message, cause="Some quorum members are syncing data"
+                )
+
+            if not self.charm.cluster.stable:
+                raise ClusterNotReadyError(
+                    message=default_message, cause="Charm has not finished initialising"
+                )
+
+        except QuorumLeaderNotFoundError:
+            raise ClusterNotReadyError(message=default_message, cause="Quorum leader not found")
+        except ConnectionClosedError:
+            raise ClusterNotReadyError(
+                message=default_message, cause="Unable to connect to the cluster"
+            )
+```
+
+#### Implementation of `build_upgrade_stack()` - VM ONLY
+
+Oftentimes, it is necessary to ensure that the workload leader is the last unit to upgrade,
+to ensure high-availability during the upgrade process.
+Here, charm authors can create a LIFO stack of unit.ids, represented as a list of unit.id strings,
+with the leader unit being at i[0].
+
+```python
+@override
+def build_upgrade_stack(self) -> list[int]:
+    upgrade_stack = []
+    for unit in self.charm.cluster.peer_units:
+        config = self.charm.cluster.unit_config(unit=unit)
+
+        # upgrade quorum leader last
+        if config["host"] == self.client.leader:
+            upgrade_stack.insert(0, int(config["unit_id"]))
+        else:
+            upgrade_stack.append(int(config["unit_id"]))
+
+    return upgrade_stack
+```
+
+#### Implementation of `_on_upgrade_granted()`
+
+On relation-changed events, each unit will check the current upgrade-stack persisted to relation data.
+If that unit is at the top of the stack, it will emit an `upgrade-granted` event, which must be handled.
+Here, workloads can be re-installed with new versions, checks can be made, data synced etc.
+If the new unit successfully rejoined the cluster, call `set_unit_completed()`.
+If the new unit failed to rejoin the cluster, call `set_unit_failed()`.
+
+NOTE - It is essential here to manually call `on_upgrade_changed` if the unit is the current leader.
+This ensures that the leader gets it's own relation-changed event, and updates the upgrade-stack for
+other units to follow suit.
+
+```python
+@override
+def _on_upgrade_granted(self, event: UpgradeGrantedEvent) -> None:
+    self.charm.snap.stop_snap_service()
+
+    if not self.charm.snap.install():
+        logger.error("Unable to install ZooKeeper Snap")
+        self.set_unit_failed()
+        return None
+
+    logger.info(f"{self.charm.unit.name} upgrading service...")
+    self.charm.snap.restart_snap_service()
+
+    try:
+        logger.debug("Running post-upgrade check...")
+        self.pre_upgrade_check()
+
+        logger.debug("Marking unit completed...")
+        self.set_unit_completed()
+
+        # ensures leader gets it's own relation-changed when it upgrades
+        if self.charm.unit.is_leader():
+            logger.debug("Re-emitting upgrade-changed on leader...")
+            self.on_upgrade_changed(event)
+
+    except ClusterNotReadyError as e:
+        logger.error(e.cause)
+        self.set_unit_failed()
+```
+
+#### Implementation of `log_rollback_instructions()`
+
+If the upgrade fails, manual intervention may be required for cluster recovery.
+Here, charm authors can log out any necessary steps to take to recover from a failed upgrade.
+When a unit fails, this library will automatically log out this message.
+
+```python
+@override
+def log_rollback_instructions(self) -> None:
+    logger.error("Upgrade failed. Please run `juju refresh` to previous version.")
+```
+
+### Instantiating in the charm and deferring events
+
+Charm authors must add a class attribute for the child class of `DataUpgrade` in the main charm.
+They must also ensure that any non-upgrade related events that may be unsafe to handle during
+an upgrade, are deferred if the unit is not in the `idle` state - i.e not currently upgrading.
+
+```python
+class ZooKeeperCharm(CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.upgrade = ZooKeeperUpgrade(
+            self,
+            relation_name = "upgrade",
+            substrate = "vm",
+            dependency_model=ZooKeeperDependencyModel(
+                **DEPENDENCIES
+            ),
+        )
+
+    def restart(self, event) -> None:
+        if not self.upgrade.state == "idle":
+            event.defer()
+            return None
+
+        self.restart_snap_service()
+```
+"""
+
+import json
+import logging
+from abc import ABC, abstractmethod
+from typing import Annotated, Dict, List, Literal, Optional, Set, Tuple
+
+import poetry.core.constraints.version as poetry_version
+from ops.charm import (
+    ActionEvent,
+    CharmBase,
+    CharmEvents,
+    RelationCreatedEvent,
+    UpgradeCharmEvent,
+)
+from ops.framework import EventBase, EventSource, Object
+from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, Relation, Unit, WaitingStatus
+from pydantic import AfterValidator, BaseModel, model_validator
+
+# The unique Charmhub library identifier, never change it
+LIBID = "156258aefb79435a93d933409a8c8684"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 1
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 0
+
+PYDEPS = ["pydantic>=2.11,<3", "poetry-core"]
+
+logger = logging.getLogger(__name__)
+
+# --- DEPENDENCY RESOLUTION FUNCTIONS ---
+
+
+def verify_requirements(version: str, requirement: str) -> bool:
+    """Verifies a specified version against defined constraint.
+
+    Args:
+        version: the version currently in use
+        requirement: Poetry version constraint
+
+    Returns:
+        True if `version` meets defined `requirement`. Otherwise False
+    """
+    return poetry_version.parse_constraint(requirement).allows(
+        poetry_version.Version.parse(version)
+    )
+
+
+# --- DEPENDENCY MODEL TYPES ---
+
+
+def validate_constraint(value: str) -> str:
+    """Validates a single version constraint string."""
+    poetry_version.parse_constraint(value)
+    return value
+
+
+VersionConstraint = Annotated[str, AfterValidator(validate_constraint)]
+
+
+class DependencyModel(BaseModel):
+    """Manager for a single dependency.
+
+    To be used as part of another model representing a collection of arbitrary dependencies.
+
+    Example::
+
+        class KafkaDependenciesModel(BaseModel):
+            kafka_charm: DependencyModel
+            kafka_service: DependencyModel
+
+        deps = {
+            "kafka_charm": {
+                "dependencies": {"zookeeper": ">5"},
+                "name": "kafka",
+                "upgrade_supported": ">5",
+                "version": "10",
+            },
+            "kafka_service": {
+                "dependencies": {"zookeeper": "^3.6"},
+                "name": "kafka",
+                "upgrade_supported": "~3.3",
+                "version": "3.3.2",
+            },
+        }
+
+        model = KafkaDependenciesModel(**deps)  # loading dict in to model
+
+        print(model.model_dump())  # exporting back validated deps
+    """
+
+    dependencies: Dict[str, VersionConstraint]
+    name: str
+    upgrade_supported: str
+    version: str
+
+    @model_validator(mode="after")
+    def version_upgrade_supported_validator(self) -> "DependencyModel":
+        """Validates specified `version` meets `upgrade_supported` requirement."""
+        if not verify_requirements(version=self.version, requirement=self.upgrade_supported):
+            raise ValueError(
+                f"upgrade_supported value {self.upgrade_supported} greater than version value {self.version} for {self.name}."
+            )
+
+        return self
+
+    def can_upgrade(self, dependency: "DependencyModel") -> bool:
+        """Compares two instances of :class:`DependencyModel` for upgradability.
+
+        Args:
+            dependency: a dependency model to compare this model against
+
+        Returns:
+            True if current model can upgrade from dependent model. Otherwise False
+        """
+        return verify_requirements(version=self.version, requirement=dependency.upgrade_supported)
+
+
+# --- CUSTOM EXCEPTIONS ---
+
+
+class UpgradeError(Exception):
+    """Base class for upgrade related exceptions in the module."""
+
+    def __init__(self, message: str, cause: Optional[str], resolution: Optional[str]):
+        super().__init__(message)
+        self.message = message
+        self.cause = cause or ""
+        self.resolution = resolution or ""
+
+    def __repr__(self):
+        """Representation of the UpgradeError class."""
+        return f"{type(self).__module__}.{type(self).__name__} - {str(vars(self))}"
+
+    def __str__(self):
+        """String representation of the UpgradeError class."""
+        return repr(self)
+
+
+class ClusterNotReadyError(UpgradeError):
+    """Exception flagging that the cluster is not ready to start upgrading.
+
+    For example, if the cluster fails :class:`DataUpgrade._on_pre_upgrade_check_action`
+
+    Args:
+        message: string message to be logged out
+        cause: short human-readable description of the cause of the error
+        resolution: short human-readable instructions for manual error resolution (optional)
+    """
+
+    def __init__(self, message: str, cause: str, resolution: Optional[str] = None):
+        super().__init__(message, cause=cause, resolution=resolution)
+
+
+class KubernetesClientError(UpgradeError):
+    """Exception flagging that a call to Kubernetes API failed.
+
+    For example, if the cluster fails :class:`DataUpgrade._set_rolling_update_partition`
+
+    Args:
+        message: string message to be logged out
+        cause: short human-readable description of the cause of the error
+        resolution: short human-readable instructions for manual error resolution (optional)
+    """
+
+    def __init__(self, message: str, cause: str, resolution: Optional[str] = None):
+        super().__init__(message, cause=cause, resolution=resolution)
+
+
+class VersionError(UpgradeError):
+    """Exception flagging that the old `version` fails to meet the new `upgrade_supported`s.
+
+    For example, upgrades from version `2.x` --> `4.x`,
+        but `4.x` only supports upgrading from `3.x` onwards
+
+    Args:
+        message: string message to be logged out
+        cause: short human-readable description of the cause of the error
+        resolution: short human-readable instructions for manual solutions to the error (optional)
+    """
+
+    def __init__(self, message: str, cause: str, resolution: Optional[str] = None):
+        super().__init__(message, cause=cause, resolution=resolution)
+
+
+class DependencyError(UpgradeError):
+    """Exception flagging that some new `dependency` is not being met.
+
+    For example, new version requires related App version `2.x`, but currently is `1.x`
+
+    Args:
+        message: string message to be logged out
+        cause: short human-readable description of the cause of the error
+        resolution: short human-readable instructions for manual solutions to the error (optional)
+    """
+
+    def __init__(self, message: str, cause: str, resolution: Optional[str] = None):
+        super().__init__(message, cause=cause, resolution=resolution)
+
+
+# --- CUSTOM EVENTS ---
+
+
+class UpgradeGrantedEvent(EventBase):
+    """Used to tell units that they can process an upgrade."""
+
+
+class UpgradeFinishedEvent(EventBase):
+    """Used to tell units that they finished the upgrade."""
+
+
+class UpgradeEvents(CharmEvents):
+    """Upgrade events.
+
+    This class defines the events that the lib can emit.
+    """
+
+    upgrade_granted = EventSource(UpgradeGrantedEvent)
+    upgrade_finished = EventSource(UpgradeFinishedEvent)
+
+
+# --- EVENT HANDLER ---
+
+
+class DataUpgrade(Object, ABC):
+    """Manages `upgrade` relation operations for in-place upgrades."""
+
+    STATES = ["recovery", "failed", "idle", "ready", "upgrading", "completed"]
+
+    on = UpgradeEvents()  # pyright: ignore [reportAssignmentType]
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        dependency_model: BaseModel,
+        relation_name: str = "upgrade",
+        substrate: Literal["vm", "k8s"] = "vm",
+    ):
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.dependency_model = dependency_model
+        self.relation_name = relation_name
+        self.substrate = substrate
+        self._upgrade_stack = None
+
+        # events
+        self.framework.observe(
+            self.charm.on[relation_name].relation_created, self._on_upgrade_created
+        )
+        self.framework.observe(
+            self.charm.on[relation_name].relation_changed, self.on_upgrade_changed
+        )
+        self.framework.observe(self.charm.on.upgrade_charm, self._on_upgrade_charm)
+        self.framework.observe(getattr(self.on, "upgrade_granted"), self._on_upgrade_granted)
+        self.framework.observe(getattr(self.on, "upgrade_finished"), self._on_upgrade_finished)
+
+        # actions
+        self.framework.observe(
+            getattr(self.charm.on, "pre_upgrade_check_action"), self._on_pre_upgrade_check_action
+        )
+        if self.substrate == "k8s":
+            self.framework.observe(
+                getattr(self.charm.on, "resume_upgrade_action"), self._on_resume_upgrade_action
+            )
+
+    @property
+    def peer_relation(self) -> Optional[Relation]:
+        """The upgrade peer relation."""
+        return self.charm.model.get_relation(self.relation_name)
+
+    @property
+    def app_units(self) -> Set[Unit]:
+        """The peer-related units in the application."""
+        if not self.peer_relation:
+            return set()
+
+        return set([self.charm.unit] + list(self.peer_relation.units))
+
+    @property
+    def state(self) -> Optional[str]:
+        """The unit state from the upgrade peer relation."""
+        if not self.peer_relation:
+            return None
+
+        return self.peer_relation.data[self.charm.unit].get("state", None)
+
+    @property
+    def stored_dependencies(self) -> Optional[BaseModel]:
+        """The application dependencies from the upgrade peer relation."""
+        if not self.peer_relation:
+            return None
+
+        if not (deps := self.peer_relation.data[self.charm.app].get("dependencies", "")):
+            return None
+
+        return type(self.dependency_model)(**json.loads(deps))
+
+    @property
+    def upgrade_stack(self) -> Optional[List[int]]:
+        """Gets the upgrade stack from the upgrade peer relation.
+
+        Unit.ids are ordered Last-In-First-Out (LIFO).
+            i.e unit.id at index `-1` is the first unit to upgrade.
+            unit.id at index `0` is the last unit to upgrade.
+
+        Returns:
+            List of integer unit.ids, ordered in upgrade order in a stack
+        """
+        if not self.peer_relation:
+            return None
+
+        # lazy-load
+        if self._upgrade_stack is None:
+            self._upgrade_stack = (
+                json.loads(self.peer_relation.data[self.charm.app].get("upgrade-stack", "[]"))
+                or None
+            )
+
+        return self._upgrade_stack
+
+    @upgrade_stack.setter
+    def upgrade_stack(self, stack: List[int]) -> None:
+        """Sets the upgrade stack to the upgrade peer relation.
+
+        Unit.ids are ordered Last-In-First-Out (LIFO).
+            i.e unit.id at index `-1` is the first unit to upgrade.
+            unit.id at index `0` is the last unit to upgrade.
+        """
+        if not self.peer_relation:
+            return
+
+        self.peer_relation.data[self.charm.app].update({"upgrade-stack": json.dumps(stack)})
+        self._upgrade_stack = stack
+
+    @property
+    def other_unit_states(self) -> list:
+        """Current upgrade state for other units.
+
+        Returns:
+            Unsorted list of upgrade states for other units.
+        """
+        if not self.peer_relation:
+            return []
+
+        return [
+            self.peer_relation.data[unit].get("state", "")
+            for unit in list(self.peer_relation.units)
+        ]
+
+    @property
+    def unit_states(self) -> list:
+        """Current upgrade state for all units.
+
+        Returns:
+            Unsorted list of upgrade states for all units.
+        """
+        if not self.peer_relation:
+            return []
+
+        return [self.peer_relation.data[unit].get("state", "") for unit in self.app_units]
+
+    @property
+    def cluster_state(self) -> Optional[str]:
+        """Current upgrade state for cluster units.
+
+        Determined from :class:`DataUpgrade.STATE`, taking the lowest ordinal unit state.
+
+        For example, if units in have states: `["ready", "upgrading", "completed"]`,
+            the overall state for the cluster is `ready`.
+
+        Returns:
+            String of upgrade state from the furthest behind unit.
+        """
+        if not self.unit_states:
+            return None
+
+        try:
+            return sorted(self.unit_states, key=self.STATES.index)[0]
+        except (ValueError, KeyError):
+            return None
+
+    @property
+    def idle(self) -> Optional[bool]:
+        """Flag for whether the cluster is in an idle upgrade state.
+
+        Returns:
+            True if all application units in idle state. Otherwise False
+        """
+        return set(self.unit_states) == {"idle"}
+
+    @abstractmethod
+    def pre_upgrade_check(self) -> None:
+        """Runs necessary checks validating the cluster is in a healthy state to upgrade.
+
+        Called by all units during :meth:`_on_pre_upgrade_check_action`.
+
+        Raises:
+            :class:`ClusterNotReadyError`: if cluster is not ready to upgrade
+        """
+        pass
+
+    def build_upgrade_stack(self) -> List[int]:
+        """Builds ordered iterable of all application unit.ids to upgrade in.
+
+        Called by leader unit during :meth:`_on_pre_upgrade_check_action`.
+
+        Returns:
+            Iterable of integer unit.ids, LIFO ordered in upgrade order
+                i.e `[5, 2, 4, 1, 3]`, unit `3` upgrades first, `5` upgrades last
+        """
+        # don't raise if k8s substrate, uses default statefulset order
+        if self.substrate == "k8s":
+            return []
+
+        raise NotImplementedError
+
+    @abstractmethod
+    def log_rollback_instructions(self) -> None:
+        """Sets charm state and logs out rollback instructions.
+
+        Called by all units when `state=failed` found during :meth:`_on_upgrade_changed`.
+        """
+        pass
+
+    def _repair_upgrade_stack(self) -> None:
+        """Ensures completed units are re-added to the upgrade-stack after failure."""
+        # need to update the stack as it was not refreshed by rollback run of pre-upgrade-check
+        # avoids difficult health check implementation by charm-authors needing to exclude dead units
+
+        # if the first unit in the stack fails, the stack will be the same length as units
+        # i.e this block not ran
+        if (
+            self.cluster_state in ["failed", "recovery"]
+            and self.upgrade_stack
+            and len(self.upgrade_stack) != len(self.app_units)
+            and self.charm.unit.is_leader()
+        ):
+            new_stack = self.upgrade_stack
+            for unit in self.app_units:
+                unit_id = int(unit.name.split("/")[1])
+
+                # if a unit fails, it rolls back first
+                if unit_id not in new_stack:
+                    new_stack.insert(-1, unit_id)
+                    logger.debug(f"Inserted {unit_id} in to upgrade-stack - {new_stack}")
+
+            self.upgrade_stack = new_stack
+
+    def set_unit_failed(self, cause: Optional[str] = None) -> None:
+        """Sets unit `state=failed` to the upgrade peer data.
+
+        Args:
+            cause: short description of cause of failure
+        """
+        if not self.peer_relation:
+            return None
+
+        # needed to refresh the stack
+        # now leader pulls a fresh stack from newly updated relation data
+        if self.charm.unit.is_leader():
+            self._upgrade_stack = None
+
+        self.charm.unit.status = BlockedStatus(cause if cause else "")
+        self.peer_relation.data[self.charm.unit].update({"state": "failed"})
+        self.log_rollback_instructions()
+
+    def set_unit_completed(self) -> None:
+        """Sets unit `state=completed` to the upgrade peer data."""
+        if not self.peer_relation:
+            return None
+
+        # needed to refresh the stack
+        # now leader pulls a fresh stack from newly updated relation data
+        if self.charm.unit.is_leader():
+            self._upgrade_stack = None
+
+        self.charm.unit.status = MaintenanceStatus("upgrade completed")
+        self.peer_relation.data[self.charm.unit].update({"state": "completed"})
+
+        # Emit upgrade_finished event to run unit's post upgrade operations.
+        if self.substrate == "k8s":
+            logger.debug(
+                f"{self.charm.unit.name} has completed the upgrade, emitting `upgrade_finished` event..."
+            )
+            getattr(self.on, "upgrade_finished").emit()
+
+    def _on_upgrade_created(self, event: RelationCreatedEvent) -> None:
+        """Handler for `upgrade-relation-created` events."""
+        if not self.peer_relation:
+            event.defer()
+            return
+
+        # setting initial idle state needed to avoid execution on upgrade-changed events
+        self.peer_relation.data[self.charm.unit].update({"state": "idle"})
+
+        if self.charm.unit.is_leader():
+            logger.debug("Persisting dependencies to upgrade relation data...")
+            self.peer_relation.data[self.charm.app].update(
+                {"dependencies": json.dumps(self.dependency_model.model_dump())}
+            )
+
+    def _on_pre_upgrade_check_action(self, event: ActionEvent) -> None:
+        """Handler for `pre-upgrade-check-action` events."""
+        if not self.peer_relation:
+            event.fail(message="Could not find upgrade relation.")
+            return
+
+        if not self.charm.unit.is_leader():
+            event.fail(message="Action must be ran on the Juju leader.")
+            return
+
+        if self.cluster_state == "failed":
+            logger.info("Entering recovery state for rolling-back to previous version...")
+            self._repair_upgrade_stack()
+            self.charm.unit.status = BlockedStatus("ready to rollback application")
+            self.peer_relation.data[self.charm.unit].update({"state": "recovery"})
+            return
+
+        # checking if upgrade in progress
+        if self.cluster_state != "idle":
+            event.fail("Cannot run pre-upgrade checks, cluster already upgrading.")
+            return
+
+        try:
+            logger.info("Running pre-upgrade-check...")
+            self.pre_upgrade_check()
+
+            if self.substrate == "k8s":
+                logger.info("Building upgrade-stack for K8s...")
+                built_upgrade_stack = sorted(
+                    [int(unit.name.split("/")[1]) for unit in self.app_units]
+                )
+            else:
+                logger.info("Building upgrade-stack for VMs...")
+                built_upgrade_stack = self.build_upgrade_stack()
+
+            logger.debug(f"Built upgrade stack of {built_upgrade_stack}")
+
+        except ClusterNotReadyError as e:
+            logger.error(e)
+            event.fail(message=e.message)
+            return
+        except Exception as e:
+            logger.error(e)
+            event.fail(message="Unknown error found.")
+            return
+
+        logger.info("Setting upgrade-stack to relation data...")
+        self.upgrade_stack = built_upgrade_stack
+
+    def _on_resume_upgrade_action(self, event: ActionEvent) -> None:
+        """Handle resume upgrade action.
+
+        Continue the upgrade by setting the partition to the next unit.
+        """
+        if not self.peer_relation:
+            event.fail(message="Could not find upgrade relation.")
+            return
+
+        if not self.charm.unit.is_leader():
+            event.fail(message="Action must be ran on the Juju leader.")
+            return
+
+        if not self.upgrade_stack:
+            event.fail(message="Nothing to resume, upgrade stack unset.")
+            return
+
+        # Check whether this is being run after juju refresh was called
+        # (the size of the upgrade stack should match the number of total
+        # unit minus one).
+        if len(self.upgrade_stack) != len(self.peer_relation.units):
+            event.fail(message="Upgrade can be resumed only once after juju refresh is called.")
+            return
+
+        try:
+            next_partition = self.upgrade_stack[-1]
+            self._set_rolling_update_partition(partition=next_partition)
+            event.set_results({"message": f"Upgrade will resume on unit {next_partition}"})
+        except KubernetesClientError:
+            event.fail(message="Cannot set rolling update partition.")
+
+    def _upgrade_supported_check(self) -> None:
+        """Checks if previous versions can be upgraded to new versions.
+
+        Raises:
+            :class:`VersionError` if upgrading to existing `version` is not supported
+        """
+        keys = self.dependency_model.__class__.model_fields.keys()
+
+        compatible = True
+        incompatibilities: List[Tuple[str, str, str, str]] = []
+        for key in keys:
+            old_dep: DependencyModel = getattr(self.stored_dependencies, key)
+            new_dep: DependencyModel = getattr(self.dependency_model, key)
+
+            if not old_dep.can_upgrade(dependency=new_dep):
+                compatible = False
+                incompatibilities.append(
+                    (key, old_dep.version, new_dep.version, new_dep.upgrade_supported)
+                )
+
+        base_message = "Versions incompatible"
+        base_cause = "Upgrades only supported for specific versions"
+        if not compatible:
+            for incompat in incompatibilities:
+                base_message += (
+                    f", {incompat[0]} {incompat[1]} can not be upgraded to {incompat[2]}"
+                )
+                base_cause += f", {incompat[0]} versions satisfying requirement {incompat[3]}"
+
+            raise VersionError(
+                message=base_message,
+                cause=base_cause,
+            )
+
+    def _on_upgrade_charm(self, event: UpgradeCharmEvent) -> None:
+        """Handler for `upgrade-charm` events."""
+        # defer if not all units have pre-upgraded
+        if not self.peer_relation:
+            event.defer()
+            return
+
+        if not self.upgrade_stack:
+            logger.error("Cluster upgrade failed, ensure pre-upgrade checks are ran first.")
+            return
+
+        if self.substrate == "vm":
+            # for VM run version checks on leader only
+            if self.charm.unit.is_leader():
+                try:
+                    self._upgrade_supported_check()
+                except VersionError as e:  # not ready if not passed check
+                    logger.error(e)
+                    self.set_unit_failed()
+                    return
+                top_unit_id = self.upgrade_stack[-1]
+                top_unit = self.charm.model.get_unit(f"{self.charm.app.name}/{top_unit_id}")
+                if (
+                    top_unit == self.charm.unit
+                    and self.peer_relation.data[self.charm.unit].get("state") == "recovery"
+                ):
+                    # While in a rollback and the Juju leader unit is the top unit in the upgrade stack, emit the event
+                    # for this unit to start the rollback.
+                    self.peer_relation.data[self.charm.unit].update({"state": "ready"})
+                    self.on_upgrade_changed(event)
+                    return
+            self.charm.unit.status = WaitingStatus("other units upgrading first...")
+            self.peer_relation.data[self.charm.unit].update({"state": "ready"})
+
+            if len(self.app_units) == 1:
+                # single unit upgrade, emit upgrade_granted event right away
+                getattr(self.on, "upgrade_granted").emit()
+
+        else:
+            # for k8s run version checks only on highest ordinal unit
+            if (
+                self.charm.unit.name
+                == f"{self.charm.app.name}/{self.charm.app.planned_units() - 1}"
+            ):
+                try:
+                    self._upgrade_supported_check()
+                except VersionError as e:  # not ready if not passed check
+                    logger.error(e)
+                    self.set_unit_failed()
+                    return
+            # On K8s an unit that receives the upgrade-charm event is upgrading
+            self.charm.unit.status = MaintenanceStatus("upgrading unit")
+            self.peer_relation.data[self.charm.unit].update({"state": "upgrading"})
+
+    def on_upgrade_changed(self, event: EventBase) -> None:
+        """Handler for `upgrade-relation-changed` events."""
+        if not self.peer_relation:
+            return
+
+        # if any other unit failed, don't continue with upgrade
+        if self.cluster_state == "failed":
+            logger.debug("Cluster failed to upgrade, exiting...")
+            return
+
+        if self.substrate == "vm" and self.cluster_state == "recovery":
+            # skip run while in recovery. The event will be retrigged when the cluster is ready
+            logger.debug("Cluster in recovery, skip...")
+            return
+
+        # if all units completed, mark as complete
+        if not self.upgrade_stack:
+            if self.state == "completed" and self.cluster_state in ["idle", "completed"]:
+                logger.info("All units completed upgrade, setting idle upgrade state...")
+                self.charm.unit.status = ActiveStatus()
+                self.peer_relation.data[self.charm.unit].update({"state": "idle"})
+
+                if self.charm.unit.is_leader():
+                    logger.debug("Persisting new dependencies to upgrade relation data...")
+                    self.peer_relation.data[self.charm.app].update(
+                        {"dependencies": json.dumps(self.dependency_model.model_dump())}
+                    )
+                return
+
+            if self.cluster_state == "idle":
+                logger.debug("upgrade-changed event handled before pre-checks, exiting...")
+                return
+
+            logger.debug("Did not find upgrade-stack or completed cluster state, skipping...")
+            return
+
+        # upgrade ongoing, set status for waiting units
+        if "upgrading" in self.unit_states and self.state in ["idle", "ready"]:
+            self.charm.unit.status = WaitingStatus("other units upgrading first...")
+
+        # pop mutates the `upgrade_stack` attr
+        top_unit_id = self.upgrade_stack.pop()
+        top_unit = self.charm.model.get_unit(f"{self.charm.app.name}/{top_unit_id}")
+        top_state = self.peer_relation.data[top_unit].get("state")
+
+        # if top of stack is completed, leader pops it
+        if self.charm.unit.is_leader() and top_state == "completed":
+            logger.debug(f"{top_unit} has finished upgrading, updating stack...")
+
+            # writes the mutated attr back to rel data
+            self.peer_relation.data[self.charm.app].update(
+                {"upgrade-stack": json.dumps(self.upgrade_stack)}
+            )
+
+            # recurse on leader to ensure relation changed event not lost
+            # in case leader is next or the last unit to complete
+            self.on_upgrade_changed(event)
+
+        # if unit top of stack and all units ready (i.e stack), emit granted event
+        if (
+            self.charm.unit == top_unit
+            and top_state in ["ready", "upgrading"]
+            and self.cluster_state == "ready"
+            and "upgrading" not in self.other_unit_states
+        ):
+            logger.debug(
+                f"{top_unit.name} is next to upgrade, emitting `upgrade_granted` event and upgrading..."
+            )
+            self.charm.unit.status = MaintenanceStatus("upgrading...")
+            self.peer_relation.data[self.charm.unit].update({"state": "upgrading"})
+
+            try:
+                getattr(self.on, "upgrade_granted").emit()
+            except DependencyError as e:
+                logger.error(e)
+                self.set_unit_failed()
+                return
+
+    def _on_upgrade_granted(self, event: UpgradeGrantedEvent) -> None:
+        """Handler for `upgrade-granted` events.
+
+        Handlers of this event must meet the following:
+            - SHOULD check for related application deps from :class:`DataUpgrade.dependencies`
+                - MAY raise :class:`DependencyError` if dependency not met
+            - MUST update unit `state` after validating the success of the upgrade, calling one of:
+                - :class:`DataUpgrade.set_unit_failed` if the unit upgrade fails
+                - :class:`DataUpgrade.set_unit_completed` if the unit upgrade succeeds
+            - MUST call :class:`DataUpgarde.on_upgrade_changed` on exit so event not lost on leader
+        """
+        # don't raise if k8s substrate, only return
+        if self.substrate == "k8s":
+            return
+
+        raise NotImplementedError
+
+    def _on_upgrade_finished(self, _) -> None:
+        """Handler for `upgrade-finished` events."""
+        if self.substrate == "vm" or not self.peer_relation:
+            return
+
+        # Emit the upgrade relation changed event in the leader to update the upgrade_stack.
+        if self.charm.unit.is_leader():
+            self.charm.on[self.relation_name].relation_changed.emit(
+                self.model.get_relation(self.relation_name)
+            )
+
+        # This hook shouldn't run for the last unit (the first that is upgraded). For that unit it
+        # should be done through an action after the upgrade success on that unit is double-checked.
+        unit_number = int(self.charm.unit.name.split("/")[1])
+        if unit_number == len(self.peer_relation.units):
+            logger.info(
+                f"{self.charm.unit.name} unit upgraded. Evaluate and run `resume-upgrade` action to continue upgrade"
+            )
+            return
+
+        # Also, the hook shouldn't run for the first unit (the last that is upgraded).
+        if unit_number == 0:
+            logger.info(f"{self.charm.unit.name} unit upgraded. Upgrade is complete")
+            return
+
+        try:
+            # Use the unit number instead of the upgrade stack to avoid race conditions
+            # (i.e. the leader updates the upgrade stack after this hook runs).
+            next_partition = unit_number - 1
+            logger.debug(f"Set rolling update partition to unit {next_partition}")
+            self._set_rolling_update_partition(partition=next_partition)
+        except KubernetesClientError:
+            logger.exception("Cannot set rolling update partition")
+            self.set_unit_failed()
+            self.log_rollback_instructions()
+
+    def _set_rolling_update_partition(self, partition: int) -> None:
+        """Patch the StatefulSet's `spec.updateStrategy.rollingUpdate.partition`.
+
+        Args:
+            partition: partition to set.
+
+        K8s only. It should decrement the rolling update strategy partition by using a code
+        like the following:
+
+            from lightkube.core.client import Client
+            from lightkube.core.exceptions import ApiError
+            from lightkube.resources.apps_v1 import StatefulSet
+
+            try:
+                patch = {"spec": {"updateStrategy": {"rollingUpdate": {"partition": partition}}}}
+                Client().patch(StatefulSet, name=self.charm.model.app.name, namespace=self.charm.model.name, obj=patch)
+                logger.debug(f"Kubernetes StatefulSet partition set to {partition}")
+            except ApiError as e:
+                if e.status.code == 403:
+                    cause = "`juju trust` needed"
+                else:
+                    cause = str(e)
+                raise KubernetesClientError("Kubernetes StatefulSet patch failed", cause)
+        """
+        if self.substrate == "vm":
+            return
+
+        raise NotImplementedError

--- a/lib/charms/data_platform_libs/v1/upgrade.py
+++ b/lib/charms/data_platform_libs/v1/upgrade.py
@@ -263,7 +263,8 @@ class ZooKeeperCharm(CharmBase):
 import json
 import logging
 from abc import ABC, abstractmethod
-from typing import Annotated, Dict, List, Literal, Optional, Set, Tuple
+from enum import IntEnum
+from typing import Annotated, Dict, List, Literal, Optional, Set, Tuple, Union
 
 import poetry.core.constraints.version as poetry_version
 from ops.charm import (
@@ -274,7 +275,15 @@ from ops.charm import (
     UpgradeCharmEvent,
 )
 from ops.framework import EventBase, EventSource, Object
-from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, Relation, Unit, WaitingStatus
+from ops.model import (
+    ActiveStatus,
+    Application,
+    BlockedStatus,
+    MaintenanceStatus,
+    Relation,
+    Unit,
+    WaitingStatus,
+)
 from pydantic import AfterValidator, BaseModel, model_validator
 
 # The unique Charmhub library identifier, never change it
@@ -290,6 +299,21 @@ LIBPATCH = 0
 PYDEPS = ["pydantic>=2,<3", "poetry-core"]
 
 logger = logging.getLogger(__name__)
+
+
+class UpgradeState(IntEnum):
+    """Integer enumeration of upgrade states.
+
+    Lower values represent states further behind in the upgrade process.
+    """
+
+    RECOVERY = 0
+    FAILED = 1
+    IDLE = 2
+    READY = 3
+    UPGRADING = 4
+    COMPLETED = 5
+
 
 # --- DEPENDENCY RESOLUTION FUNCTIONS ---
 
@@ -543,12 +567,9 @@ class DataUpgrade(Object, ABC):
         return set([self.charm.unit] + list(self.peer_relation.units))
 
     @property
-    def state(self) -> Optional[str]:
+    def state(self) -> Optional[UpgradeState]:
         """The unit state from the upgrade peer relation."""
-        if not self.peer_relation:
-            return None
-
-        return self.peer_relation.data[self.charm.unit].get("state", None)
+        return self._get_unit_state(self.charm.unit)
 
     @property
     def stored_dependencies(self) -> Optional[BaseModel]:
@@ -599,7 +620,7 @@ class DataUpgrade(Object, ABC):
         self._upgrade_stack = stack
 
     @property
-    def other_unit_states(self) -> list:
+    def other_unit_states(self) -> List[Optional[UpgradeState]]:
         """Current upgrade state for other units.
 
         Returns:
@@ -608,51 +629,77 @@ class DataUpgrade(Object, ABC):
         if not self.peer_relation:
             return []
 
-        return [
-            self.peer_relation.data[unit].get("state", "")
-            for unit in list(self.peer_relation.units)
-        ]
+        return [self._get_unit_state(unit) for unit in self.peer_relation.units]
 
     @property
-    def unit_states(self) -> list:
+    def unit_states(self) -> List[Optional[UpgradeState]]:
         """Current upgrade state for all units.
 
         Returns:
             Unsorted list of upgrade states for all units.
         """
-        if not self.peer_relation:
-            return []
-
-        return [self.peer_relation.data[unit].get("state", "") for unit in self.app_units]
+        return [self._get_unit_state(unit) for unit in self.app_units]
 
     @property
-    def cluster_state(self) -> Optional[str]:
+    def cluster_state(self) -> Optional[UpgradeState]:
         """Current upgrade state for cluster units.
 
-        Determined from :class:`DataUpgrade.STATE`, taking the lowest ordinal unit state.
+        Determined taking the lowest ordinal unit state.
 
-        For example, if units in have states: `["ready", "upgrading", "completed"]`,
-            the overall state for the cluster is `ready`.
+        For example, if units have states: `[READY, UPGRADING, COMPLETED]`,
+            the overall state for the cluster is `READY`.
 
         Returns:
-            String of upgrade state from the furthest behind unit.
+            UpgradeState enum of the furthest behind unit, or None if invalid.
         """
-        if not self.unit_states:
-            return None
+        states = self.unit_states
 
-        try:
-            return sorted(self.unit_states, key=self.STATES.index)[0]
-        except (ValueError, KeyError):
-            return None
+        # Build a strictly typed list to satisfy type checker of min
+        valid_states: List[UpgradeState] = []
+        for state in states:
+            if state is None:
+                return None
+            valid_states.append(state)
+
+        return min(valid_states)
 
     @property
-    def idle(self) -> Optional[bool]:
+    def idle(self) -> bool:
         """Flag for whether the cluster is in an idle upgrade state.
 
         Returns:
-            True if all application units in idle state. Otherwise False
+            True if all application units in idle state. Otherwise, False.
         """
-        return set(self.unit_states) == {"idle"}
+        if not self.unit_states:
+            return False
+
+        return set(self.unit_states) == {UpgradeState.IDLE}
+
+    def _get_unit_state(self, unit) -> Optional[UpgradeState]:
+        """Helper to safely parse the state string from relation data into an Enum."""
+        if not self.peer_relation:
+            return None
+
+        state_str = self.peer_relation.data[unit].get("state", "")
+        if not state_str:
+            return None
+
+        try:
+            return UpgradeState[state_str.upper()]
+        except KeyError:
+            return None
+
+    def _set_state(self, entity: Union[Unit, Application], state: UpgradeState) -> None:
+        """Helper to safely write an Enum state to the relation databag.
+
+        Args:
+            entity: The Juju Unit or Application to update the data for.
+            state: The UpgradeState enum to serialize and save.
+        """
+        if not self.peer_relation:
+            return
+
+        self.peer_relation.data[entity].update({"state": state.name.lower()})
 
     @abstractmethod
     def pre_upgrade_check(self) -> None:
@@ -696,7 +743,7 @@ class DataUpgrade(Object, ABC):
         # if the first unit in the stack fails, the stack will be the same length as units
         # i.e this block not ran
         if (
-            self.cluster_state in ["failed", "recovery"]
+            self.cluster_state in [UpgradeState.FAILED, UpgradeState.RECOVERY]
             and self.upgrade_stack
             and len(self.upgrade_stack) != len(self.app_units)
             and self.charm.unit.is_leader()
@@ -727,7 +774,7 @@ class DataUpgrade(Object, ABC):
             self._upgrade_stack = None
 
         self.charm.unit.status = BlockedStatus(cause if cause else "")
-        self.peer_relation.data[self.charm.unit].update({"state": "failed"})
+        self._set_state(self.charm.unit, UpgradeState.FAILED)
         self.log_rollback_instructions()
 
     def set_unit_completed(self) -> None:
@@ -741,7 +788,7 @@ class DataUpgrade(Object, ABC):
             self._upgrade_stack = None
 
         self.charm.unit.status = MaintenanceStatus("upgrade completed")
-        self.peer_relation.data[self.charm.unit].update({"state": "completed"})
+        self._set_state(self.charm.unit, UpgradeState.COMPLETED)
 
         # Emit upgrade_finished event to run unit's post upgrade operations.
         if self.substrate == "k8s":
@@ -757,7 +804,7 @@ class DataUpgrade(Object, ABC):
             return
 
         # setting initial idle state needed to avoid execution on upgrade-changed events
-        self.peer_relation.data[self.charm.unit].update({"state": "idle"})
+        self._set_state(self.charm.unit, UpgradeState.IDLE)
 
         if self.charm.unit.is_leader():
             logger.debug("Persisting dependencies to upgrade relation data...")
@@ -772,18 +819,18 @@ class DataUpgrade(Object, ABC):
             return
 
         if not self.charm.unit.is_leader():
-            event.fail(message="Action must be ran on the Juju leader.")
+            event.fail(message="Action must be run on the Juju leader.")
             return
 
-        if self.cluster_state == "failed":
+        if self.cluster_state == UpgradeState.FAILED:
             logger.info("Entering recovery state for rolling-back to previous version...")
             self._repair_upgrade_stack()
             self.charm.unit.status = BlockedStatus("ready to rollback application")
-            self.peer_relation.data[self.charm.unit].update({"state": "recovery"})
+            self._set_state(self.charm.unit, UpgradeState.RECOVERY)
             return
 
         # checking if upgrade in progress
-        if self.cluster_state != "idle":
+        if self.cluster_state != UpgradeState.IDLE:
             event.fail("Cannot run pre-upgrade checks, cluster already upgrading.")
             return
 
@@ -851,32 +898,31 @@ class DataUpgrade(Object, ABC):
         Raises:
             :class:`VersionError` if upgrading to existing `version` is not supported
         """
-        keys = self.dependency_model.model_fields.keys()
+        stored_deps = self.stored_dependencies
+        if not stored_deps:
+            return
 
-        compatible = True
         incompatibilities: List[Tuple[str, str, str, str]] = []
-        for key in keys:
-            old_dep: DependencyModel = getattr(self.stored_dependencies, key)
+
+        for key in self.dependency_model.model_fields.keys():
+            old_dep: DependencyModel = getattr(stored_deps, key)
             new_dep: DependencyModel = getattr(self.dependency_model, key)
 
             if not old_dep.can_upgrade(dependency=new_dep):
-                compatible = False
                 incompatibilities.append(
                     (key, old_dep.version, new_dep.version, new_dep.upgrade_supported)
                 )
 
-        base_message = "Versions incompatible"
-        base_cause = "Upgrades only supported for specific versions"
-        if not compatible:
-            for incompat in incompatibilities:
-                base_message += (
-                    f", {incompat[0]} {incompat[1]} can not be upgraded to {incompat[2]}"
-                )
-                base_cause += f", {incompat[0]} versions satisfying requirement {incompat[3]}"
+        if incompatibilities:
+            messages = []
+            causes = []
+            for name, old_ver, new_ver, required_ver in incompatibilities:
+                messages.append(f", {name} {old_ver} can not be upgraded to {new_ver}")
+                causes.append(f"{name} versions satisfying requirement {required_ver}")
 
             raise VersionError(
-                message=base_message,
-                cause=base_cause,
+                message=f"Versions incompatible, {', '.join(messages)}",
+                cause=f"Upgrades only supported for specific versions, {', '.join(causes)}",
             )
 
     def _on_upgrade_charm(self, event: UpgradeCharmEvent) -> None:
@@ -903,15 +949,15 @@ class DataUpgrade(Object, ABC):
                 top_unit = self.charm.model.get_unit(f"{self.charm.app.name}/{top_unit_id}")
                 if (
                     top_unit == self.charm.unit
-                    and self.peer_relation.data[self.charm.unit].get("state") == "recovery"
+                    and self._get_unit_state(self.charm.unit) == UpgradeState.RECOVERY
                 ):
                     # While in a rollback and the Juju leader unit is the top unit in the upgrade stack, emit the event
                     # for this unit to start the rollback.
-                    self.peer_relation.data[self.charm.unit].update({"state": "ready"})
+                    self._set_state(self.charm.unit, UpgradeState.READY)
                     self.on_upgrade_changed(event)
                     return
             self.charm.unit.status = WaitingStatus("other units upgrading first...")
-            self.peer_relation.data[self.charm.unit].update({"state": "ready"})
+            self._set_state(self.charm.unit, UpgradeState.READY)
 
             if len(self.app_units) == 1:
                 # single unit upgrade, emit upgrade_granted event right away
@@ -931,7 +977,7 @@ class DataUpgrade(Object, ABC):
                     return
             # On K8s an unit that receives the upgrade-charm event is upgrading
             self.charm.unit.status = MaintenanceStatus("upgrading unit")
-            self.peer_relation.data[self.charm.unit].update({"state": "upgrading"})
+            self._set_state(self.charm.unit, UpgradeState.UPGRADING)
 
     def on_upgrade_changed(self, event: EventBase) -> None:
         """Handler for `upgrade-relation-changed` events."""
@@ -939,21 +985,25 @@ class DataUpgrade(Object, ABC):
             return
 
         # if any other unit failed, don't continue with upgrade
-        if self.cluster_state == "failed":
+        if self.cluster_state == UpgradeState.FAILED:
             logger.debug("Cluster failed to upgrade, exiting...")
             return
 
-        if self.substrate == "vm" and self.cluster_state == "recovery":
+        if self.substrate == "vm" and self.cluster_state == UpgradeState.RECOVERY:
             # skip run while in recovery. The event will be retrigged when the cluster is ready
             logger.debug("Cluster in recovery, skip...")
             return
 
         # if all units completed, mark as complete
         if not self.upgrade_stack:
-            if self.state == "completed" and self.cluster_state in ["idle", "completed"]:
+            if self.state == UpgradeState.COMPLETED and self.cluster_state in [
+                UpgradeState.IDLE,
+                UpgradeState.COMPLETED,
+            ]:
                 logger.info("All units completed upgrade, setting idle upgrade state...")
                 self.charm.unit.status = ActiveStatus()
-                self.peer_relation.data[self.charm.unit].update({"state": "idle"})
+
+                self._set_state(self.charm.unit, UpgradeState.IDLE)
 
                 if self.charm.unit.is_leader():
                     logger.debug("Persisting new dependencies to upgrade relation data...")
@@ -962,7 +1012,7 @@ class DataUpgrade(Object, ABC):
                     )
                 return
 
-            if self.cluster_state == "idle":
+            if self.cluster_state == UpgradeState.IDLE:
                 logger.debug("upgrade-changed event handled before pre-checks, exiting...")
                 return
 
@@ -970,16 +1020,19 @@ class DataUpgrade(Object, ABC):
             return
 
         # upgrade ongoing, set status for waiting units
-        if "upgrading" in self.unit_states and self.state in ["idle", "ready"]:
+        if UpgradeState.UPGRADING in self.unit_states and self.state in [
+            UpgradeState.IDLE,
+            UpgradeState.READY,
+        ]:
             self.charm.unit.status = WaitingStatus("other units upgrading first...")
 
         # pop mutates the `upgrade_stack` attr
         top_unit_id = self.upgrade_stack.pop()
         top_unit = self.charm.model.get_unit(f"{self.charm.app.name}/{top_unit_id}")
-        top_state = self.peer_relation.data[top_unit].get("state")
+        top_state = self._get_unit_state(top_unit)
 
         # if top of stack is completed, leader pops it
-        if self.charm.unit.is_leader() and top_state == "completed":
+        if self.charm.unit.is_leader() and top_state == UpgradeState.COMPLETED:
             logger.debug(f"{top_unit} has finished upgrading, updating stack...")
 
             # writes the mutated attr back to rel data
@@ -994,15 +1047,15 @@ class DataUpgrade(Object, ABC):
         # if unit top of stack and all units ready (i.e stack), emit granted event
         if (
             self.charm.unit == top_unit
-            and top_state in ["ready", "upgrading"]
-            and self.cluster_state == "ready"
-            and "upgrading" not in self.other_unit_states
+            and top_state in [UpgradeState.READY, UpgradeState.UPGRADING]
+            and self.cluster_state == UpgradeState.READY
+            and UpgradeState.UPGRADING not in self.other_unit_states
         ):
             logger.debug(
                 f"{top_unit.name} is next to upgrade, emitting `upgrade_granted` event and upgrading..."
             )
             self.charm.unit.status = MaintenanceStatus("upgrading...")
-            self.peer_relation.data[self.charm.unit].update({"state": "upgrading"})
+            self._set_state(self.charm.unit, UpgradeState.UPGRADING)
 
             try:
                 getattr(self.on, "upgrade_granted").emit()
@@ -1020,7 +1073,7 @@ class DataUpgrade(Object, ABC):
             - MUST update unit `state` after validating the success of the upgrade, calling one of:
                 - :class:`DataUpgrade.set_unit_failed` if the unit upgrade fails
                 - :class:`DataUpgrade.set_unit_completed` if the unit upgrade succeeds
-            - MUST call :class:`DataUpgarde.on_upgrade_changed` on exit so event not lost on leader
+            - MUST call :class:`DataUpgrade.on_upgrade_changed` on exit so event not lost on leader
         """
         # don't raise if k8s substrate, only return
         if self.substrate == "k8s":
@@ -1036,7 +1089,7 @@ class DataUpgrade(Object, ABC):
         # Emit the upgrade relation changed event in the leader to update the upgrade_stack.
         if self.charm.unit.is_leader():
             self.charm.on[self.relation_name].relation_changed.emit(
-                self.model.get_relation(self.relation_name)
+                self.charm.model.get_relation(self.relation_name)
             )
 
         # This hook shouldn't run for the last unit (the first that is upgraded). For that unit it

--- a/lib/charms/data_platform_libs/v1/upgrade.py
+++ b/lib/charms/data_platform_libs/v1/upgrade.py
@@ -287,7 +287,7 @@ LIBAPI = 1
 # to 0 if you are raising the major API version
 LIBPATCH = 0
 
-PYDEPS = ["pydantic>=2.11,<3", "poetry-core"]
+PYDEPS = ["pydantic>=2,<3", "poetry-core"]
 
 logger = logging.getLogger(__name__)
 
@@ -296,6 +296,9 @@ logger = logging.getLogger(__name__)
 
 def verify_requirements(version: str, requirement: str) -> bool:
     """Verifies a specified version against defined constraint.
+
+    Supports Poetry version constraints
+    https://python-poetry.org/docs/dependency-specification/#version-constraints
 
     Args:
         version: the version currently in use
@@ -354,7 +357,7 @@ class DependencyModel(BaseModel):
 
     dependencies: Dict[str, VersionConstraint]
     name: str
-    upgrade_supported: str
+    upgrade_supported: VersionConstraint
     version: str
 
     @model_validator(mode="after")
@@ -556,7 +559,7 @@ class DataUpgrade(Object, ABC):
         if not (deps := self.peer_relation.data[self.charm.app].get("dependencies", "")):
             return None
 
-        return type(self.dependency_model)(**json.loads(deps))
+        return type(self.dependency_model).model_validate_json(deps)
 
     @property
     def upgrade_stack(self) -> Optional[List[int]]:
@@ -759,7 +762,7 @@ class DataUpgrade(Object, ABC):
         if self.charm.unit.is_leader():
             logger.debug("Persisting dependencies to upgrade relation data...")
             self.peer_relation.data[self.charm.app].update(
-                {"dependencies": json.dumps(self.dependency_model.model_dump())}
+                {"dependencies": self.dependency_model.model_dump_json()}
             )
 
     def _on_pre_upgrade_check_action(self, event: ActionEvent) -> None:
@@ -848,7 +851,7 @@ class DataUpgrade(Object, ABC):
         Raises:
             :class:`VersionError` if upgrading to existing `version` is not supported
         """
-        keys = self.dependency_model.__class__.model_fields.keys()
+        keys = self.dependency_model.model_fields.keys()
 
         compatible = True
         incompatibilities: List[Tuple[str, str, str, str]] = []
@@ -955,7 +958,7 @@ class DataUpgrade(Object, ABC):
                 if self.charm.unit.is_leader():
                     logger.debug("Persisting new dependencies to upgrade relation data...")
                     self.peer_relation.data[self.charm.app].update(
-                        {"dependencies": json.dumps(self.dependency_model.model_dump())}
+                        {"dependencies": self.dependency_model.model_dump_json()}
                     )
                 return
 

--- a/lib/charms/data_platform_libs/v1/upgrade.py
+++ b/lib/charms/data_platform_libs/v1/upgrade.py
@@ -515,8 +515,6 @@ class UpgradeEvents(CharmEvents):
 class DataUpgrade(Object, ABC):
     """Manages `upgrade` relation operations for in-place upgrades."""
 
-    STATES = ["recovery", "failed", "idle", "ready", "upgrading", "completed"]
-
     on = UpgradeEvents()  # pyright: ignore [reportAssignmentType]
 
     def __init__(

--- a/requirements/v1/requirements.txt
+++ b/requirements/v1/requirements.txt
@@ -1,2 +1,3 @@
 ops >= 2.1.1
 pydantic>=2.11,<3
+poetry-core

--- a/tests/v0/integration/database-charm/src/charm.py
+++ b/tests/v0/integration/database-charm/src/charm.py
@@ -348,7 +348,7 @@ class DatabaseCharm(CharmBase):
     def _on_set_relation_field(self, event: ActionEvent):
         """Set requested relation field."""
         relation = self._get_relation(event.params["relation_id"])
-        # Charms should be compatible with old vesrions, to simulate rolling upgrade
+        # Charms should be compatible with old versions, to simulate rolling upgrade
         if DATA_INTERFACES_VERSION > 17:
             self.database.update_relation_data(
                 relation.id, {event.params["field"]: event.params["value"]}
@@ -361,7 +361,7 @@ class DatabaseCharm(CharmBase):
     def _on_delete_relation_field(self, event: ActionEvent):
         """Delete requested relation field."""
         relation = self._get_relation(event.params["relation_id"])
-        # Charms should be compatible with old vesrions, to simulate rolling upgrade
+        # Charms should be compatible with old versions, to simulate rolling upgrade
         if DATA_INTERFACES_VERSION > 17:
             self.database.delete_relation_data(relation.id, [event.params["field"]])
         else:
@@ -414,7 +414,7 @@ class DatabaseCharm(CharmBase):
         """Set requested relation field."""
         component = event.params["component"]
 
-        # Charms should be compatible with old vesrions, to simulate rolling upgrade
+        # Charms should be compatible with old versions, to simulate rolling upgrade
         if DATA_INTERFACES_VERSION <= 17:
             relation = self.model.get_relation(PEER)
             if component == "app":
@@ -439,7 +439,7 @@ class DatabaseCharm(CharmBase):
         component = event.params["component"]
         count = event.params["count"]
 
-        # Charms should be compatible with old vesrions, to simulate rolling upgrade
+        # Charms should be compatible with old versions, to simulate rolling upgrade
         for cnt in range(count):
             value = event.params["value"] + f"{cnt}"
             if DATA_INTERFACES_VERSION <= 17:
@@ -465,7 +465,7 @@ class DatabaseCharm(CharmBase):
         """Set requested relation field."""
         component = event.params["component"]
 
-        # Charms should be compatible with old vesrions, to simulate rolling upgrade
+        # Charms should be compatible with old versions, to simulate rolling upgrade
         if DATA_INTERFACES_VERSION <= 17:
             relation = self.model.get_relation(PEER)
             if component == "app":
@@ -495,7 +495,7 @@ class DatabaseCharm(CharmBase):
         """Delete requested relation field."""
         component = event.params["component"]
 
-        # Charms should be compatible with old vesrions, to simulate rolling upgrade
+        # Charms should be compatible with old versions, to simulate rolling upgrade
         if DATA_INTERFACES_VERSION <= 17:
             relation = self.model.get_relation(PEER)
             if component == "app":
@@ -528,7 +528,7 @@ class DatabaseCharm(CharmBase):
         """Delete requested relation field."""
         component = event.params["component"]
 
-        # Charms should be compatible with old vesrions, to simulate rolling upgrade
+        # Charms should be compatible with old versions, to simulate rolling upgrade
         if DATA_INTERFACES_VERSION <= 17:
             return
 

--- a/tests/v1/integration/database-charm/src/charm.py
+++ b/tests/v1/integration/database-charm/src/charm.py
@@ -367,7 +367,7 @@ class DatabaseCharm(CharmBase):
         model = self.database.interface.build_model(relation.id, DataContract)
         for request in model.requests:
             setattr(request, event.params["field"].replace("-", "_"), None)
-        # Charms should be compatible with old vesrions, to simulatrams["field"])
+        # Charms should be compatible with old versions, to simulatrams["field"])
         self.database.interface.write_model(relation.id, model)
 
     def _new_rolename(self) -> str:
@@ -424,7 +424,7 @@ class DatabaseCharm(CharmBase):
         component = event.params["component"]
         count = event.params["count"]
 
-        # Charms should be compatible with old vesrions, to simulate rolling upgrade
+        # Charms should be compatible with old versions, to simulate rolling upgrade
         for cnt in range(count):
             value = event.params["value"] + f"{cnt}"
             if component == "app":

--- a/tests/v1/unit/test_upgrade.py
+++ b/tests/v1/unit/test_upgrade.py
@@ -1,0 +1,1103 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import json
+import logging
+
+import pytest
+from ops.charm import CharmBase
+from ops.model import BlockedStatus
+from ops.testing import Harness
+from pydantic import ValidationError
+
+from charms.data_platform_libs.v1.upgrade import (
+    BaseModel,
+    DataUpgrade,
+    DependencyModel,
+    KubernetesClientError,
+    VersionError,
+    verify_requirements,
+)
+
+logger = logging.getLogger(__name__)
+
+GANDALF_METADATA = """
+name: gandalf
+peers:
+  upgrade:
+    interface: upgrade
+"""
+
+GANDALF_ACTIONS = """
+pre-upgrade-check:
+  description: "YOU SHALL NOT PASS"
+resume-upgrade:
+  description: “The wise speak only of what they know.”
+"""
+
+GANDALF_DEPS = {
+    "gandalf_the_white": {
+        "dependencies": {"gandalf_the_grey": ">5"},
+        "name": "gandalf",
+        "upgrade_supported": ">1.2",
+        "version": "7",
+    },
+}
+
+
+class GandalfModel(BaseModel):
+    gandalf_the_white: DependencyModel
+
+
+class GandalfUpgrade(DataUpgrade):
+    def pre_upgrade_check(self):
+        pass
+
+    def log_rollback_instructions(self):
+        pass
+
+    def _on_upgrade_granted(self, _):
+        pass
+
+
+class GandalfCharm(CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+
+
+@pytest.fixture
+def harness():
+    harness = Harness(GandalfCharm, meta=GANDALF_METADATA, actions=GANDALF_ACTIONS)
+    harness.begin()
+    return harness
+
+
+@pytest.mark.parametrize(
+    "requirement,version,output",
+    [
+        ("^1.2.3", "1.2.2", False),
+        ("^1.2.3", "1.2.3", True),
+        ("^1.2.3", "1.2.4", True),
+        ("^1.2.3", "1.3.4", True),
+        ("^1.2.3", "2.2.3", False),
+        ("^1.2.3", "2.0.0", False),
+        ("^1.2", "0.9.2", False),
+        ("^1.2", "1.0.0", False),
+        ("^1.2", "1.2.0", True),
+        ("^1.2", "1.3.0", True),
+        ("^1.2", "1.3", True),
+        ("^1.2", "2", False),
+        ("^1.2", "2.2", False),
+        ("^1.2", "2.2.0", False),
+        ("^1", "0.9.2", False),
+        ("^1", "1.0.0", True),
+        ("^1", "1.2.0", True),
+        ("^1", "1.3.0", True),
+        ("^1", "1.3", True),
+        ("^1", "2", False),
+        ("^1", "2.2", False),
+        ("^1", "2.2.0", False),
+        ("^0.2.3", "0.2.2", False),
+        ("^0.2.3", "0.2.3", True),
+        ("^0.2.3", "0.3.0", False),
+        ("^0.2.3", "1.2.0", False),
+        ("^0.0.3", "0.0.2", False),
+        ("^0.0.3", "0.0.4", False),
+        ("^0.0.3", "0.1.4", False),
+        ("^0.0.3", "1.1.4", False),
+        ("^0.0", "0", True),
+        ("^0.0", "0.0.1", True),
+        ("^0.0", "0.1", False),
+        ("^0.0", "1.0", False),
+        ("^0", "0", True),
+        ("^0", "0.0", True),
+        ("^0", "0.0.0", True),
+        ("^0", "0.1.0", True),
+        ("^0", "0.1.6", True),
+        ("^0", "0.1", True),
+        ("^0", "1.0", False),
+        ("^0", "0.9.9", True),
+    ],
+)
+def test_verify_caret_requirements(requirement, version, output):
+    assert verify_requirements(version=version, requirement=requirement) == output
+
+
+@pytest.mark.parametrize(
+    "requirement,version,output",
+    [
+        ("~1.2.3", "1.2.2", False),
+        ("~1.2.3", "1.3.2", False),
+        ("~1.2.3", "1.3.5", False),
+        ("~1.2.3", "1.2.5", True),
+        ("~1.2.3", "1.2", False),
+        ("~1.2", "1.2", True),
+        ("~1.2", "1.6", False),
+        ("~1.2", "1.2.4", True),
+        ("~1.2", "1.1", False),
+        ("~1.2", "1.0.5", False),
+        ("~0.2", "0.2", True),
+        ("~0.2", "0.2.3", True),
+        ("~0.2", "0.3", False),
+        ("~1", "0.3", False),
+        ("~1", "1.3", True),
+        ("~1", "0.0.9", False),
+        ("~1", "0.9.9", False),
+        ("~1", "1.9.9", True),
+        ("~1", "1.7", True),
+        ("~1", "1", True),
+        ("~0", "1", False),
+        ("~0", "0.1", True),
+        ("~0", "0.5.9", True),
+    ],
+)
+def test_verify_tilde_requirements(requirement, version, output):
+    assert verify_requirements(version=version, requirement=requirement) == output
+
+
+@pytest.mark.parametrize(
+    "requirement,version,output",
+    [
+        ("*", "1.5.6", True),
+        ("*", "0.0.1", True),
+        ("*", "0.2.0", True),
+        ("*", "1.0.0", True),
+        ("1.*", "1.0.0", True),
+        ("1.*", "2.0.0", False),
+        ("1.*", "0.6.2", False),
+        ("1.2.*", "0.6.2", False),
+        ("1.2.*", "1.6.2", False),
+        ("1.2.*", "1.2.2", True),
+        ("1.2.*", "1.2.0", True),
+        ("1.2.*", "1.1.6", False),
+        ("1.2.*", "1.1.0", False),
+        ("0.2.*", "1.1.0", False),
+        ("0.2.*", "0.1.0", False),
+        ("0.2.*", "0.2.9", True),
+        ("0.2.*", "0.6.0", False),
+    ],
+)
+def test_verify_wildcard_requirements(requirement, version, output):
+    assert verify_requirements(version=version, requirement=requirement) == output
+
+
+@pytest.mark.parametrize(
+    "requirement,version,output",
+    [
+        ("0.1", "0.1", True),
+        ("0.1", "0.2", False),
+        (">1", "1.8", True),
+        (">1", "8.8.0", True),
+        (">0", "8.8.0", True),
+        (">0", "0.0", False),
+        (">0", "0.0.0", False),
+        (">0", "0.0.1", True),
+        (">1.0", "1.0.0", False),
+        (">1.0", "1.0", False),
+        (">1.0", "1.5.6", True),
+        (">1.0", "2.0", True),
+        (">1.0", "0.0.4", False),
+        (">1.6", "1.3", False),
+        (">1.6", "1.3.8", False),
+        (">1.6", "1.35.8", True),
+        (">1.6.3", "1.7.8", True),
+        (">1.22.3", "1.7.8", False),
+        (">0.22.3", "1.7.8", True),
+        (">=1.0", "1.0.0", True),
+        (">=1.0", "1.0", True),
+        (">=0.2", "0.2", True),
+        (">=0.2.7", "0.2.7", True),
+        (">=1.0", "1.5.6", True),
+        (">=1", "1", True),
+        (">=1", "1.0", True),
+        (">=1", "1.0.0", True),
+        (">=1", "1.0.6", True),
+        (">=1", "0.0", False),
+        (">=1", "0.0.1", False),
+        (">=1.0", "2.0", True),
+        (">=1.0", "0.0.4", False),
+        (">=1.6", "1.3", False),
+        (">=1.6", "1.3.8", False),
+        (">=1.6", "1.35.8", True),
+        (">=1.6.3", "1.7.8", True),
+        (">=1.22.3", "1.7.8", False),
+        (">=0.22.3", "1.7.8", True),
+    ],
+)
+def test_verify_inequality_requirements(requirement, version, output):
+    assert verify_requirements(version=version, requirement=requirement) == output
+
+
+def test_dependency_model_raises_for_incompatible_version():
+    deps = {
+        "gandalf_the_white": {
+            "dependencies": {"gandalf_the_grey": ">5"},
+            "name": "gandalf",
+            "upgrade_supported": ">5",
+            "version": "4",
+        },
+    }
+
+    with pytest.raises(ValidationError):
+        GandalfModel(**deps)
+
+
+@pytest.mark.parametrize("value", ["saruman", ""])
+def test_dependency_model_raises_for_bad_dependency(value):
+    deps = {
+        "gandalf_the_white": {
+            "dependencies": {"gandalf_the_grey": value},
+            "name": "gandalf",
+            "upgrade_supported": ">6",
+            "version": "7",
+        },
+    }
+
+    with pytest.raises(ValidationError):
+        GandalfModel(**deps)
+
+
+@pytest.mark.parametrize("value", ["balrog", ""])
+def test_dependency_model_raises_for_bad_nested_dependency(value):
+    deps = {
+        "gandalf_the_white": {
+            "dependencies": {"gandalf_the_grey": "~1.0", "bilbo": value},
+            "name": "gandalf",
+            "upgrade_supported": ">6",
+            "version": "7",
+        },
+    }
+
+    with pytest.raises(ValidationError):
+        GandalfModel(**deps)
+
+
+@pytest.mark.parametrize("value", ["saruman", "1.3", ""])
+def test_dependency_model_raises_for_bad_upgrade_supported(value):
+    deps = {
+        "gandalf_the_white": {
+            "dependencies": {"gandalf_the_grey": ">5"},
+            "name": "gandalf",
+            "upgrade_supported": value,
+            "version": "7",
+        },
+    }
+
+    with pytest.raises(ValidationError):
+        GandalfModel(**deps)
+
+
+def test_dependency_model_succeeds():
+    GandalfModel(**GANDALF_DEPS)
+
+
+def test_dependency_model_succeeds_nested():
+    deps = {
+        "gandalf_the_white": {
+            "dependencies": {"gandalf_the_grey": "~1.0", "bilbo": "^1.2.5"},
+            "name": "gandalf",
+            "upgrade_supported": ">1.2",
+            "version": "7",
+        },
+    }
+
+    GandalfModel(**deps)
+
+
+@pytest.mark.parametrize(
+    "min_state",
+    [
+        ("failed"),
+        ("idle"),
+        ("ready"),
+        ("upgrading"),
+        ("completed"),
+    ],
+)
+def test_cluster_state(harness, min_state):
+    gandalf_model = GandalfModel(**GANDALF_DEPS)
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=gandalf_model, substrate="k8s"
+    )
+    harness.add_relation("upgrade", "gandalf")
+
+    harness.set_leader(True)
+
+    harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/1")
+
+    with harness.hooks_disabled():
+        harness.update_relation_data(
+            harness.charm.upgrade.peer_relation.id, "gandalf/0", {"state": min_state}
+        )
+        harness.update_relation_data(
+            harness.charm.upgrade.peer_relation.id, "gandalf/1", {"state": "completed"}
+        )
+
+    assert harness.charm.upgrade.cluster_state == min_state
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        ("failed"),
+        ("idle"),
+        ("ready"),
+        ("upgrading"),
+        ("completed"),
+    ],
+)
+def test_idle(harness, state):
+    gandalf_model = GandalfModel(**GANDALF_DEPS)
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=gandalf_model, substrate="k8s"
+    )
+    harness.add_relation("upgrade", "gandalf")
+
+    harness.set_leader(True)
+
+    harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/1")
+
+    with harness.hooks_disabled():
+        harness.update_relation_data(
+            harness.charm.upgrade.peer_relation.id, "gandalf/0", {"state": state}
+        )
+        harness.update_relation_data(
+            harness.charm.upgrade.peer_relation.id, "gandalf/1", {"state": "idle"}
+        )
+
+    assert harness.charm.upgrade.idle == (state == "idle")
+
+
+def test_data_upgrade_raises_on_init(harness):
+    # nothing implemented
+    class GandalfUpgrade(DataUpgrade):
+        pass
+
+    with pytest.raises(TypeError):
+        GandalfUpgrade(charm=harness.charm, dependency_model=GandalfModel)
+
+    # missing pre-upgrade-check
+    class GandalfUpgrade(DataUpgrade):
+        def log_rollback_instructions(self):
+            pass
+
+        def _on_upgrade_granted(self, _):
+            pass
+
+    with pytest.raises(TypeError):
+        GandalfUpgrade(charm=harness.charm, dependency_model=GandalfModel)
+
+    # missing missing log-rollback-instructions
+    class GandalfUpgrade(DataUpgrade):
+        def pre_upgrade_check(self):
+            pass
+
+        def _on_upgrade_granted(self, _):
+            pass
+
+    with pytest.raises(TypeError):
+        GandalfUpgrade(charm=harness.charm, dependency_model=GandalfModel)
+
+
+def test_on_upgrade_granted_raises_not_implemented_vm(harness, mocker):
+    # missing on-upgrade-granted
+    class GandalfUpgrade(DataUpgrade):
+        def pre_upgrade_check(self):
+            pass
+
+        def log_rollback_instructions(self):
+            pass
+
+    gandalf = GandalfUpgrade(charm=harness.charm, dependency_model=GandalfModel)
+    with pytest.raises(NotImplementedError):
+        mock_event = mocker.MagicMock()
+        gandalf._on_upgrade_granted(mock_event)
+
+
+def test_on_upgrade_granted_succeeds_k8s(harness, mocker):
+    class GandalfUpgrade(DataUpgrade):
+        def pre_upgrade_check(self):
+            pass
+
+        def log_rollback_instructions(self):
+            pass
+
+    gandalf = GandalfUpgrade(charm=harness.charm, dependency_model=GandalfModel, substrate="k8s")
+    mock_event = mocker.MagicMock()
+    gandalf._on_upgrade_granted(mock_event)
+
+
+def test_data_upgrade_succeeds(harness):
+    GandalfUpgrade(charm=harness.charm, dependency_model=GandalfModel)
+
+
+def test_build_upgrade_stack_raises_not_implemented_vm(harness):
+    gandalf = GandalfUpgrade(charm=harness.charm, dependency_model=GandalfModel)
+    with pytest.raises(NotImplementedError):
+        gandalf.build_upgrade_stack()
+
+
+def test_build_upgrade_stack_succeeds_k8s(harness):
+    gandalf = GandalfUpgrade(charm=harness.charm, dependency_model=GandalfModel, substrate="k8s")
+    gandalf.build_upgrade_stack()
+
+
+def test_set_rolling_update_partition_succeeds_vm(harness):
+    gandalf = GandalfUpgrade(charm=harness.charm, dependency_model=GandalfModel)
+    gandalf._set_rolling_update_partition(0)
+
+
+def test_set_rolling_update_partition_raises_not_implemented_k8s(harness):
+    gandalf = GandalfUpgrade(charm=harness.charm, dependency_model=GandalfModel, substrate="k8s")
+    with pytest.raises(NotImplementedError):
+        gandalf._set_rolling_update_partition(0)
+
+
+def test_set_unit_failed_resets_stack(harness, mocker):
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=GandalfModel(**GANDALF_DEPS), substrate="k8s"
+    )
+    harness.add_relation("upgrade", "gandalf")
+    harness.charm.upgrade.upgrade_stack = [0]
+    harness.set_leader(True)
+    log_spy = mocker.spy(GandalfUpgrade, "log_rollback_instructions")
+
+    assert harness.charm.upgrade._upgrade_stack
+
+    harness.charm.upgrade.set_unit_failed()
+
+    assert not harness.charm.upgrade._upgrade_stack
+
+    assert isinstance(harness.charm.unit.status, BlockedStatus)
+    assert log_spy.call_count == 1
+
+
+@pytest.mark.parametrize("substrate,upgrade_finished_call_count", [("vm", 0), ("k8s", 1)])
+def test_set_unit_completed_resets_stack(harness, mocker, substrate, upgrade_finished_call_count):
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=GandalfModel(**GANDALF_DEPS), substrate=substrate
+    )
+    harness.add_relation("upgrade", "gandalf")
+    harness.charm.upgrade.upgrade_stack = [0]
+    harness.set_leader(True)
+
+    assert harness.charm.upgrade._upgrade_stack
+
+    upgrade_finished_spy = mocker.spy(harness.charm.upgrade, "_on_upgrade_finished")
+
+    harness.charm.upgrade.set_unit_completed()
+
+    assert not harness.charm.upgrade._upgrade_stack
+
+    assert upgrade_finished_spy.call_count == upgrade_finished_call_count
+
+
+def test_upgrade_created_sets_idle_and_deps(harness):
+    gandalf_model = GandalfModel(**GANDALF_DEPS)
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=gandalf_model, substrate="k8s"
+    )
+    harness.set_leader(True)
+
+    # relation-created
+    harness.add_relation("upgrade", "gandalf")
+
+    assert harness.charm.upgrade.peer_relation
+    assert harness.charm.upgrade.peer_relation.data[harness.charm.unit].get("state") == "idle"
+    assert (
+        json.loads(
+            harness.charm.upgrade.peer_relation.data[harness.charm.app].get("dependencies", "")
+        )
+        == GANDALF_DEPS
+    )
+
+
+def test_pre_upgrade_check_action_fails_non_leader(harness, mocker):
+    gandalf_model = GandalfModel(**GANDALF_DEPS)
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=gandalf_model, substrate="k8s"
+    )
+    harness.add_relation("upgrade", "gandalf")
+
+    mock_event = mocker.MagicMock()
+    harness.charm.upgrade._on_pre_upgrade_check_action(mock_event)
+
+    mock_event.fail.assert_called_once()
+
+
+def test_pre_upgrade_check_action_fails_already_upgrading(harness, mocker):
+    gandalf_model = GandalfModel(**GANDALF_DEPS)
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=gandalf_model, substrate="k8s"
+    )
+    harness.add_relation("upgrade", "gandalf")
+
+    harness.set_leader(True)
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "ready"})
+
+    mock_event = mocker.MagicMock()
+    harness.charm.upgrade._on_pre_upgrade_check_action(mock_event)
+
+    mock_event.fail.assert_called_once()
+
+
+def test_pre_upgrade_check_action_runs_pre_upgrade_checks(harness, mocker):
+    gandalf_model = GandalfModel(**GANDALF_DEPS)
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=gandalf_model, substrate="k8s"
+    )
+    harness.add_relation("upgrade", "gandalf")
+
+    harness.set_leader(True)
+
+    mocker.patch.object(harness.charm.upgrade, "pre_upgrade_check")
+    mock_event = mocker.MagicMock()
+    harness.charm.upgrade._on_pre_upgrade_check_action(mock_event)
+
+    harness.charm.upgrade.pre_upgrade_check.assert_called_once()
+
+
+def test_pre_upgrade_check_action_builds_upgrade_stack_vm(harness, mocker):
+    gandalf_model = GandalfModel(**GANDALF_DEPS)
+    harness.charm.upgrade = GandalfUpgrade(charm=harness.charm, dependency_model=gandalf_model)
+    harness.add_relation("upgrade", "gandalf")
+
+    harness.set_leader(True)
+
+    mocker.patch.object(harness.charm.upgrade, "build_upgrade_stack", return_value=[1, 2, 3])
+    mock_event = mocker.MagicMock()
+    harness.charm.upgrade._on_pre_upgrade_check_action(mock_event)
+
+    harness.charm.upgrade.build_upgrade_stack.assert_called_once()
+
+    relation_stack = harness.charm.upgrade.peer_relation.data[harness.charm.app].get(
+        "upgrade-stack", ""
+    )
+
+    assert relation_stack
+    assert json.loads(relation_stack) == harness.charm.upgrade.upgrade_stack
+    assert json.loads(relation_stack) == [1, 2, 3]
+
+
+def test_pre_upgrade_check_action_builds_upgrade_stack_k8s(harness, mocker):
+    gandalf_model = GandalfModel(**GANDALF_DEPS)
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=gandalf_model, substrate="k8s"
+    )
+    harness.add_relation("upgrade", "gandalf")
+
+    harness.set_leader(True)
+
+    harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/1")
+    harness.update_relation_data(
+        harness.charm.upgrade.peer_relation.id, "gandalf/1", {"state": "idle"}
+    )
+
+    mock_event = mocker.MagicMock()
+    harness.charm.upgrade._on_pre_upgrade_check_action(mock_event)
+
+    relation_stack = harness.charm.upgrade.peer_relation.data[harness.charm.app].get(
+        "upgrade-stack", ""
+    )
+
+    assert relation_stack
+    assert json.loads(relation_stack) == harness.charm.upgrade.upgrade_stack
+    assert json.loads(relation_stack) == [0, 1]
+
+
+def test_pre_upgrade_check_recovers_stack(harness, mocker):
+    gandalf_model = GandalfModel(**GANDALF_DEPS)
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=gandalf_model, substrate="k8s"
+    )
+    harness.add_relation("upgrade", "gandalf")
+
+    mocker.patch.object(GandalfUpgrade, "_repair_upgrade_stack")
+
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "failed"})
+    harness.set_leader(True)
+
+    mock_event = mocker.MagicMock()
+    harness.charm.upgrade._on_pre_upgrade_check_action(mock_event)
+
+    GandalfUpgrade._repair_upgrade_stack.assert_called_once()
+    assert isinstance(harness.charm.unit.status, BlockedStatus)
+    assert harness.charm.upgrade.state == "recovery"
+
+
+def test_resume_upgrade_action_fails_non_leader(harness, mocker):
+    gandalf_model = GandalfModel(**GANDALF_DEPS)
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=gandalf_model, substrate="k8s"
+    )
+    harness.add_relation("upgrade", "gandalf")
+
+    mock_event = mocker.MagicMock()
+    harness.charm.upgrade._on_resume_upgrade_action(mock_event)
+
+    mock_event.fail.assert_called_once()
+
+
+def test_resume_upgrade_action_fails_without_upgrade_stack(harness, mocker):
+    gandalf_model = GandalfModel(**GANDALF_DEPS)
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=gandalf_model, substrate="k8s"
+    )
+    harness.add_relation("upgrade", "gandalf")
+
+    harness.set_leader(True)
+
+    mock_event = mocker.MagicMock()
+    harness.charm.upgrade._on_resume_upgrade_action(mock_event)
+
+    mock_event.fail.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "upgrade_stack, has_k8s_error, has_succeeded",
+    [([0], False, False), ([0, 1, 2], False, False), ([0, 1], False, True), ([0, 1], True, False)],
+)
+def test_resume_upgrade_action_succeeds_only_when_ran_at_the_right_moment(
+    harness, mocker, upgrade_stack, has_k8s_error, has_succeeded
+):
+    class GandalfUpgrade(DataUpgrade):
+        def pre_upgrade_check(self):
+            pass
+
+        def log_rollback_instructions(self):
+            pass
+
+        def _set_rolling_update_partition(self, partition: int):
+            if has_k8s_error:
+                raise KubernetesClientError("fake message", "fake cause")
+
+    gandalf_model = GandalfModel(**GANDALF_DEPS)
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=gandalf_model, substrate="k8s"
+    )
+    harness.add_relation("upgrade", "gandalf")
+    for number in range(1, 3):
+        harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, f"gandalf/{number}")
+
+    harness.set_leader(True)
+
+    harness.update_relation_data(
+        harness.charm.upgrade.peer_relation.id,
+        "gandalf",
+        {"upgrade-stack": json.dumps(upgrade_stack)},
+    )
+
+    mock_event = mocker.MagicMock()
+    harness.charm.upgrade._on_resume_upgrade_action(mock_event)
+
+    assert mock_event.fail.call_count == (0 if has_succeeded else 1)
+    assert mock_event.set_results.call_count == (1 if has_succeeded else 0)
+
+
+def test_upgrade_supported_check_fails(harness):
+    bad_deps = {
+        "gandalf_the_white": {
+            "dependencies": {"gandalf_the_grey": ">5"},
+            "name": "gandalf",
+            "upgrade_supported": "~0.2",
+            "version": "0.2.1",
+        },
+    }
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=GandalfModel(**GANDALF_DEPS), substrate="k8s"
+    )
+
+    harness.add_relation("upgrade", "gandalf")
+
+    harness.update_relation_data(
+        harness.charm.upgrade.peer_relation.id, "gandalf", {"dependencies": json.dumps(bad_deps)}
+    )
+
+    with pytest.raises(VersionError):
+        harness.charm.upgrade._upgrade_supported_check()
+
+
+def test_upgrade_supported_check_succeeds(harness):
+    good_deps = {
+        "gandalf_the_white": {
+            "dependencies": {"gandalf_the_grey": ">5"},
+            "name": "gandalf",
+            "upgrade_supported": ">0.2",
+            "version": "1.3",
+        },
+    }
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=GandalfModel(**GANDALF_DEPS), substrate="k8s"
+    )
+
+    harness.add_relation("upgrade", "gandalf")
+
+    harness.update_relation_data(
+        harness.charm.upgrade.peer_relation.id, "gandalf", {"dependencies": json.dumps(good_deps)}
+    )
+
+    harness.charm.upgrade._upgrade_supported_check()
+
+
+def test_upgrade_charm_runs_checks_on_leader(harness, mocker):
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=GandalfModel(**GANDALF_DEPS), substrate="k8s"
+    )
+    harness.add_relation("upgrade", "gandalf")
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "idle"})
+    harness.charm.upgrade.upgrade_stack = [0]
+
+    mocker.patch.object(harness.charm.upgrade, "_upgrade_supported_check")
+    harness.charm.on.upgrade_charm.emit()
+
+    harness.charm.upgrade._upgrade_supported_check.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "substrate,leader,call_count,state",
+    [
+        ("vm", True, 1, "ready"),
+        ("vm", False, 0, "ready"),
+        ("k8s", True, 0, "upgrading"),
+        ("k8s", False, 0, "upgrading"),
+    ],
+)
+def test_upgrade_charm_runs_upgrade_changed_on_leader_first_to_rollback(
+    harness, mocker, substrate, leader, call_count, state
+):
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=GandalfModel(**GANDALF_DEPS), substrate=substrate
+    )
+    harness.add_relation("upgrade", "gandalf")
+    harness.set_leader(leader)
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "recovery"})
+    harness.charm.upgrade.upgrade_stack = [2, 1, 0]
+
+    mocker.patch.object(harness.charm.upgrade, "_upgrade_supported_check")
+    mocker.patch.object(harness.charm.upgrade, "on_upgrade_changed")
+    harness.charm.on.upgrade_charm.emit()
+
+    assert harness.charm.upgrade.on_upgrade_changed.call_count == call_count
+    assert harness.charm.upgrade.state == state
+
+
+@pytest.mark.parametrize(
+    "substrate,initial_state,upgrade_stack,final_state",
+    [
+        ("vm", "idle", [2, 1, 0], "ready"),
+        ("vm", "recovery", [2, 0, 1], "ready"),
+        ("vm", "recovery", [0, 2, 1], "ready"),
+        ("k8s", "recovery", [2, 1, 0], "upgrading"),
+    ],
+)
+def test_upgrade_charm_doesnt_run_upgrade_changed_on_leader_not_first_to_rollback(
+    harness, mocker, substrate, initial_state, upgrade_stack, final_state
+):
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=GandalfModel(**GANDALF_DEPS), substrate=substrate
+    )
+    harness.add_relation("upgrade", "gandalf")
+    harness.set_leader(True)
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": initial_state})
+    harness.charm.upgrade.upgrade_stack = upgrade_stack
+
+    mocker.patch.object(harness.charm.upgrade, "_upgrade_supported_check")
+    mocker.patch.object(harness.charm.upgrade, "on_upgrade_changed")
+    harness.charm.on.upgrade_charm.emit()
+
+    harness.charm.upgrade.on_upgrade_changed.assert_not_called()
+    assert harness.charm.upgrade.state == final_state
+
+
+@pytest.mark.parametrize("substrate,state", [("vm", "ready"), ("k8s", "upgrading")])
+def test_upgrade_charm_sets_right_state(harness, mocker, substrate, state):
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=GandalfModel(**GANDALF_DEPS), substrate=substrate
+    )
+    harness.add_relation("upgrade", "gandalf")
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "idle"})
+    harness.charm.upgrade.upgrade_stack = [0]
+
+    mocker.patch.object(harness.charm.upgrade, "_upgrade_supported_check")
+    harness.charm.on.upgrade_charm.emit()
+
+    assert harness.charm.upgrade.state == state
+
+
+def test_upgrade_changed_return_if_recovery(harness, caplog):
+    caplog.set_level(logging.DEBUG)
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=GandalfModel(**GANDALF_DEPS), substrate="vm"
+    )
+    harness.add_relation("upgrade", "gandalf")
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "recovery"})
+
+    with harness.hooks_disabled():
+        harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/1")
+
+    harness.update_relation_data(
+        harness.charm.upgrade.peer_relation.id, "gandalf/1", {"state": "failed"}
+    )
+
+    assert len(caplog.records) == 1
+    assert caplog.records[-1].message == "Cluster in recovery, skip..."
+
+
+def test_upgrade_changed_sets_idle_and_deps_if_all_completed(harness):
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=GandalfModel(**GANDALF_DEPS), substrate="k8s"
+    )
+    harness.add_relation("upgrade", "gandalf")
+
+    assert not harness.charm.upgrade.stored_dependencies
+
+    harness.charm.upgrade.upgrade_stack = []
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "completed"})
+    harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/1")
+    harness.set_leader()
+    harness.update_relation_data(
+        harness.charm.upgrade.peer_relation.id, "gandalf/1", {"state": "completed"}
+    )
+
+    assert harness.charm.upgrade.state == "idle"
+    assert harness.charm.upgrade.stored_dependencies == GandalfModel(**GANDALF_DEPS)
+
+
+def test_upgrade_changed_sets_idle_and_deps_if_some_completed_idle(harness):
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=GandalfModel(**GANDALF_DEPS), substrate="k8s"
+    )
+    harness.add_relation("upgrade", "gandalf")
+
+    assert not harness.charm.upgrade.stored_dependencies == GandalfModel(**GANDALF_DEPS)
+
+    harness.charm.upgrade.upgrade_stack = []
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "completed"})
+    harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/1")
+    harness.set_leader()
+    harness.update_relation_data(
+        harness.charm.upgrade.peer_relation.id, "gandalf/1", {"state": "idle"}
+    )
+
+    assert harness.charm.upgrade.state == "idle"
+    assert harness.charm.upgrade.stored_dependencies == GandalfModel(**GANDALF_DEPS)
+
+
+def test_upgrade_changed_does_not_recurse_if_called_all_idle(harness, mocker):
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=GandalfModel(**GANDALF_DEPS), substrate="k8s"
+    )
+    harness.add_relation("upgrade", "gandalf")
+    harness.charm.upgrade.upgrade_stack = []
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "idle"})
+    harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/1")
+    harness.set_leader(True)
+
+    mocker.patch.object(harness.charm.upgrade, "on_upgrade_changed")
+    harness.update_relation_data(
+        harness.charm.upgrade.peer_relation.id, "gandalf/1", {"state": "idle"}
+    )
+
+    harness.charm.upgrade.on_upgrade_changed.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "pre_state,stack,call_count,post_state",
+    [
+        ("idle", [0, 1], 0, "idle"),
+        ("idle", [1, 0], 0, "idle"),
+        ("ready", [0, 1], 0, "ready"),
+        ("ready", [1, 0], 1, "upgrading"),
+    ],
+)
+def test_upgrade_changed_emits_upgrade_granted_only_if_top_of_stack(
+    harness, mocker, pre_state, stack, call_count, post_state
+):
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=GandalfModel(**GANDALF_DEPS), substrate="k8s"
+    )
+
+    with harness.hooks_disabled():
+        harness.add_relation("upgrade", "gandalf")
+        harness.charm.upgrade.upgrade_stack = stack
+        harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/1")
+        harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": pre_state})
+
+    upgrade_granted_spy = mocker.spy(harness.charm.upgrade, "_on_upgrade_granted")
+
+    harness.update_relation_data(
+        harness.charm.upgrade.peer_relation.id, "gandalf/1", {"state": "ready"}
+    )
+
+    assert upgrade_granted_spy.call_count == call_count
+    assert harness.charm.upgrade.state == post_state
+
+
+def test_upgrade_changed_emits_upgrade_granted_only_if_all_ready(harness, mocker):
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=GandalfModel(**GANDALF_DEPS), substrate="k8s"
+    )
+
+    with harness.hooks_disabled():
+        harness.add_relation("upgrade", "gandalf")
+        harness.charm.upgrade.upgrade_stack = [1, 0]
+        harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/1")
+        harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "ready"})
+
+    upgrade_granted_spy = mocker.spy(harness.charm.upgrade, "_on_upgrade_granted")
+
+    harness.update_relation_data(
+        harness.charm.upgrade.peer_relation.id, "gandalf/1", {"state": "idle"}
+    )
+
+    assert upgrade_granted_spy.call_count == 0
+    assert harness.charm.upgrade.state == "ready"
+
+
+@pytest.mark.parametrize(
+    "substrate,is_leader,unit_number,call_count,has_k8s_error",
+    [
+        ("vm", False, 1, 0, False),
+        ("k8s", True, 3, 0, False),
+        ("k8s", True, 0, 0, False),
+        ("k8s", True, 1, 1, False),
+        ("k8s", True, 2, 1, False),
+        ("k8s", False, 1, 1, False),
+        ("k8s", False, 1, 1, True),
+    ],
+)
+def test_upgrade_finished_calls_set_rolling_update_partition_only_for_right_units_on_k8s(
+    harness, mocker, substrate, is_leader, unit_number, call_count, has_k8s_error
+):
+    class GandalfUpgrade(DataUpgrade):
+        def pre_upgrade_check(self):
+            pass
+
+        def log_rollback_instructions(self):
+            pass
+
+        def _set_rolling_update_partition(self, partition: int):
+            if has_k8s_error:
+                raise KubernetesClientError("fake message", "fake cause")
+
+        def set_unit_failed(self):
+            pass
+
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=GandalfModel(**GANDALF_DEPS), substrate=substrate
+    )
+
+    with harness.hooks_disabled():
+        harness.set_leader(is_leader)
+        harness.add_relation("upgrade", "gandalf")
+        harness.charm.unit.name = f"gandalf/{unit_number}"
+        for number in range(4):
+            if number != unit_number:
+                harness.add_relation_unit(
+                    harness.charm.upgrade.peer_relation.id, f"gandalf/{number}"
+                )
+
+    set_partition_spy = mocker.spy(harness.charm.upgrade, "_set_rolling_update_partition")
+    set_unit_failed_spy = mocker.spy(harness.charm.upgrade, "set_unit_failed")
+    log_rollback_instructions_spy = mocker.spy(harness.charm.upgrade, "log_rollback_instructions")
+
+    mock_event = mocker.MagicMock()
+    harness.charm.upgrade._on_upgrade_finished(mock_event)
+
+    assert set_partition_spy.call_count == call_count
+    assert set_unit_failed_spy.call_count == (1 if has_k8s_error else 0)
+    assert log_rollback_instructions_spy.call_count == (1 if has_k8s_error else 0)
+
+
+def test_upgrade_changed_recurses_on_leader_and_clears_stack(harness, mocker):
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=GandalfModel(**GANDALF_DEPS), substrate="k8s"
+    )
+    harness.add_relation("upgrade", "gandalf")
+    harness.charm.upgrade.upgrade_stack = [0, 1]
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "ready"})
+    harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/1")
+    harness.set_leader(True)
+
+    upgrade_changed_spy = mocker.spy(harness.charm.upgrade, "on_upgrade_changed")
+
+    harness.update_relation_data(
+        harness.charm.upgrade.peer_relation.id, "gandalf/1", {"state": "completed"}
+    )
+
+    # once for top of stack 1, once for leader 0
+    assert upgrade_changed_spy.call_count == 2
+    assert harness.charm.upgrade.upgrade_stack == []
+    assert json.loads(
+        harness.charm.upgrade.peer_relation.data[harness.charm.app].get("upgrade-stack", "")
+    ) == [0]
+
+
+def test_upgrade_changed_does_not_recurse_or_change_stack_non_leader(harness, mocker):
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=GandalfModel(**GANDALF_DEPS), substrate="k8s"
+    )
+    harness.add_relation("upgrade", "gandalf")
+    harness.charm.upgrade.upgrade_stack = [0, 1]
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "ready"})
+    harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/1")
+
+    upgrade_changed_spy = mocker.spy(harness.charm.upgrade, "on_upgrade_changed")
+
+    harness.update_relation_data(
+        harness.charm.upgrade.peer_relation.id, "gandalf/1", {"state": "completed"}
+    )
+
+    # once for top of stack 1
+    assert upgrade_changed_spy.call_count == 1
+    assert json.loads(
+        harness.charm.upgrade.peer_relation.data[harness.charm.app].get("upgrade-stack", "")
+    ) == [0, 1]
+
+
+def test_repair_upgrade_stack_puts_failed_unit_first_in_stack(harness):
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=GandalfModel(**GANDALF_DEPS), substrate="k8s"
+    )
+    harness.add_relation("upgrade", "gandalf")
+    harness.charm.upgrade.upgrade_stack = [0, 2]
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "ready"})
+    harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/1")
+    harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/2")
+    harness.set_leader(True)
+
+    with harness.hooks_disabled():
+        harness.update_relation_data(
+            harness.charm.upgrade.peer_relation.id, "gandalf/1", {"state": "completed"}
+        )
+        harness.update_relation_data(
+            harness.charm.upgrade.peer_relation.id, "gandalf/2", {"state": "failed"}
+        )
+
+    harness.charm.upgrade._repair_upgrade_stack()
+
+    assert harness.charm.upgrade.upgrade_stack == [0, 1, 2]
+
+
+def test_repair_upgrade_stack_does_not_modify_existing_stack(harness):
+    harness.charm.upgrade = GandalfUpgrade(
+        charm=harness.charm, dependency_model=GandalfModel(**GANDALF_DEPS), substrate="k8s"
+    )
+    harness.add_relation("upgrade", "gandalf")
+    harness.charm.upgrade.upgrade_stack = [0, 2, 1]
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "ready"})
+    harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/1")
+    harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/2")
+    harness.set_leader(True)
+
+    with harness.hooks_disabled():
+        harness.update_relation_data(
+            harness.charm.upgrade.peer_relation.id, "gandalf/1", {"state": "failed"}
+        )
+        harness.update_relation_data(
+            harness.charm.upgrade.peer_relation.id, "gandalf/2", {"state": "ready"}
+        )
+
+    harness.charm.upgrade._repair_upgrade_stack()
+
+    assert harness.charm.upgrade.upgrade_stack == [0, 2, 1]

--- a/tests/v1/unit/test_upgrade.py
+++ b/tests/v1/unit/test_upgrade.py
@@ -15,6 +15,7 @@ from charms.data_platform_libs.v1.upgrade import (
     DataUpgrade,
     DependencyModel,
     KubernetesClientError,
+    UpgradeState,
     VersionError,
     verify_requirements,
 )
@@ -307,11 +308,11 @@ def test_dependency_model_succeeds_nested():
 @pytest.mark.parametrize(
     "min_state",
     [
-        ("failed"),
-        ("idle"),
-        ("ready"),
-        ("upgrading"),
-        ("completed"),
+        UpgradeState.FAILED,
+        UpgradeState.IDLE,
+        UpgradeState.READY,
+        UpgradeState.UPGRADING,
+        UpgradeState.COMPLETED,
     ],
 )
 def test_cluster_state(harness, min_state):
@@ -327,10 +328,12 @@ def test_cluster_state(harness, min_state):
 
     with harness.hooks_disabled():
         harness.update_relation_data(
-            harness.charm.upgrade.peer_relation.id, "gandalf/0", {"state": min_state}
+            harness.charm.upgrade.peer_relation.id, "gandalf/0", {"state": min_state.name.lower()}
         )
         harness.update_relation_data(
-            harness.charm.upgrade.peer_relation.id, "gandalf/1", {"state": "completed"}
+            harness.charm.upgrade.peer_relation.id,
+            "gandalf/1",
+            {"state": UpgradeState.COMPLETED.name.lower()},
         )
 
     assert harness.charm.upgrade.cluster_state == min_state
@@ -339,11 +342,11 @@ def test_cluster_state(harness, min_state):
 @pytest.mark.parametrize(
     "state",
     [
-        ("failed"),
-        ("idle"),
-        ("ready"),
-        ("upgrading"),
-        ("completed"),
+        UpgradeState.FAILED,
+        UpgradeState.IDLE,
+        UpgradeState.READY,
+        UpgradeState.UPGRADING,
+        UpgradeState.COMPLETED,
     ],
 )
 def test_idle(harness, state):
@@ -359,13 +362,15 @@ def test_idle(harness, state):
 
     with harness.hooks_disabled():
         harness.update_relation_data(
-            harness.charm.upgrade.peer_relation.id, "gandalf/0", {"state": state}
+            harness.charm.upgrade.peer_relation.id, "gandalf/0", {"state": state.name.lower()}
         )
         harness.update_relation_data(
-            harness.charm.upgrade.peer_relation.id, "gandalf/1", {"state": "idle"}
+            harness.charm.upgrade.peer_relation.id,
+            "gandalf/1",
+            {"state": UpgradeState.IDLE.name.lower()},
         )
 
-    assert harness.charm.upgrade.idle == (state == "idle")
+    assert harness.charm.upgrade.idle == (state.name.lower() == UpgradeState.IDLE.name.lower())
 
 
 def test_data_upgrade_raises_on_init(harness):
@@ -503,7 +508,10 @@ def test_upgrade_created_sets_idle_and_deps(harness):
     harness.add_relation("upgrade", "gandalf")
 
     assert harness.charm.upgrade.peer_relation
-    assert harness.charm.upgrade.peer_relation.data[harness.charm.unit].get("state") == "idle"
+    assert (
+        harness.charm.upgrade.peer_relation.data[harness.charm.unit].get("state")
+        == UpgradeState.IDLE.name.lower()
+    )
     assert (
         json.loads(
             harness.charm.upgrade.peer_relation.data[harness.charm.app].get("dependencies", "")
@@ -533,7 +541,9 @@ def test_pre_upgrade_check_action_fails_already_upgrading(harness, mocker):
     harness.add_relation("upgrade", "gandalf")
 
     harness.set_leader(True)
-    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "ready"})
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update(
+        {"state": UpgradeState.READY.name.lower()}
+    )
 
     mock_event = mocker.MagicMock()
     harness.charm.upgrade._on_pre_upgrade_check_action(mock_event)
@@ -590,7 +600,9 @@ def test_pre_upgrade_check_action_builds_upgrade_stack_k8s(harness, mocker):
 
     harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/1")
     harness.update_relation_data(
-        harness.charm.upgrade.peer_relation.id, "gandalf/1", {"state": "idle"}
+        harness.charm.upgrade.peer_relation.id,
+        "gandalf/1",
+        {"state": UpgradeState.IDLE.name.lower()},
     )
 
     mock_event = mocker.MagicMock()
@@ -614,7 +626,9 @@ def test_pre_upgrade_check_recovers_stack(harness, mocker):
 
     mocker.patch.object(GandalfUpgrade, "_repair_upgrade_stack")
 
-    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "failed"})
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update(
+        {"state": UpgradeState.FAILED.name.lower()}
+    )
     harness.set_leader(True)
 
     mock_event = mocker.MagicMock()
@@ -622,7 +636,7 @@ def test_pre_upgrade_check_recovers_stack(harness, mocker):
 
     GandalfUpgrade._repair_upgrade_stack.assert_called_once()
     assert isinstance(harness.charm.unit.status, BlockedStatus)
-    assert harness.charm.upgrade.state == "recovery"
+    assert harness.charm.upgrade.state == UpgradeState.RECOVERY
 
 
 def test_resume_upgrade_action_fails_non_leader(harness, mocker):
@@ -744,7 +758,9 @@ def test_upgrade_charm_runs_checks_on_leader(harness, mocker):
         charm=harness.charm, dependency_model=GandalfModel(**GANDALF_DEPS), substrate="k8s"
     )
     harness.add_relation("upgrade", "gandalf")
-    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "idle"})
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update(
+        {"state": UpgradeState.IDLE.name.lower()}
+    )
     harness.charm.upgrade.upgrade_stack = [0]
 
     mocker.patch.object(harness.charm.upgrade, "_upgrade_supported_check")
@@ -756,10 +772,10 @@ def test_upgrade_charm_runs_checks_on_leader(harness, mocker):
 @pytest.mark.parametrize(
     "substrate,leader,call_count,state",
     [
-        ("vm", True, 1, "ready"),
-        ("vm", False, 0, "ready"),
-        ("k8s", True, 0, "upgrading"),
-        ("k8s", False, 0, "upgrading"),
+        ("vm", True, 1, UpgradeState.READY),
+        ("vm", False, 0, UpgradeState.READY),
+        ("k8s", True, 0, UpgradeState.UPGRADING),
+        ("k8s", False, 0, UpgradeState.UPGRADING),
     ],
 )
 def test_upgrade_charm_runs_upgrade_changed_on_leader_first_to_rollback(
@@ -770,7 +786,9 @@ def test_upgrade_charm_runs_upgrade_changed_on_leader_first_to_rollback(
     )
     harness.add_relation("upgrade", "gandalf")
     harness.set_leader(leader)
-    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "recovery"})
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update(
+        {"state": UpgradeState.RECOVERY.name.lower()}
+    )
     harness.charm.upgrade.upgrade_stack = [2, 1, 0]
 
     mocker.patch.object(harness.charm.upgrade, "_upgrade_supported_check")
@@ -784,10 +802,10 @@ def test_upgrade_charm_runs_upgrade_changed_on_leader_first_to_rollback(
 @pytest.mark.parametrize(
     "substrate,initial_state,upgrade_stack,final_state",
     [
-        ("vm", "idle", [2, 1, 0], "ready"),
-        ("vm", "recovery", [2, 0, 1], "ready"),
-        ("vm", "recovery", [0, 2, 1], "ready"),
-        ("k8s", "recovery", [2, 1, 0], "upgrading"),
+        ("vm", UpgradeState.IDLE, [2, 1, 0], UpgradeState.READY),
+        ("vm", UpgradeState.RECOVERY, [2, 0, 1], UpgradeState.READY),
+        ("vm", UpgradeState.RECOVERY, [0, 2, 1], UpgradeState.READY),
+        ("k8s", UpgradeState.RECOVERY, [2, 1, 0], UpgradeState.UPGRADING),
     ],
 )
 def test_upgrade_charm_doesnt_run_upgrade_changed_on_leader_not_first_to_rollback(
@@ -798,7 +816,9 @@ def test_upgrade_charm_doesnt_run_upgrade_changed_on_leader_not_first_to_rollbac
     )
     harness.add_relation("upgrade", "gandalf")
     harness.set_leader(True)
-    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": initial_state})
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update(
+        {"state": initial_state.name.lower()}
+    )
     harness.charm.upgrade.upgrade_stack = upgrade_stack
 
     mocker.patch.object(harness.charm.upgrade, "_upgrade_supported_check")
@@ -809,13 +829,17 @@ def test_upgrade_charm_doesnt_run_upgrade_changed_on_leader_not_first_to_rollbac
     assert harness.charm.upgrade.state == final_state
 
 
-@pytest.mark.parametrize("substrate,state", [("vm", "ready"), ("k8s", "upgrading")])
+@pytest.mark.parametrize(
+    "substrate,state", [("vm", UpgradeState.READY), ("k8s", UpgradeState.UPGRADING)]
+)
 def test_upgrade_charm_sets_right_state(harness, mocker, substrate, state):
     harness.charm.upgrade = GandalfUpgrade(
         charm=harness.charm, dependency_model=GandalfModel(**GANDALF_DEPS), substrate=substrate
     )
     harness.add_relation("upgrade", "gandalf")
-    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "idle"})
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update(
+        {"state": UpgradeState.IDLE.name.lower()}
+    )
     harness.charm.upgrade.upgrade_stack = [0]
 
     mocker.patch.object(harness.charm.upgrade, "_upgrade_supported_check")
@@ -852,14 +876,18 @@ def test_upgrade_changed_sets_idle_and_deps_if_all_completed(harness):
     assert not harness.charm.upgrade.stored_dependencies
 
     harness.charm.upgrade.upgrade_stack = []
-    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "completed"})
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update(
+        {"state": UpgradeState.COMPLETED.name.lower()}
+    )
     harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/1")
-    harness.set_leader()
+    harness.set_leader(True)
     harness.update_relation_data(
-        harness.charm.upgrade.peer_relation.id, "gandalf/1", {"state": "completed"}
+        harness.charm.upgrade.peer_relation.id,
+        "gandalf/1",
+        {"state": UpgradeState.COMPLETED.name.lower()},
     )
 
-    assert harness.charm.upgrade.state == "idle"
+    assert harness.charm.upgrade.state == UpgradeState.IDLE
     assert harness.charm.upgrade.stored_dependencies == GandalfModel(**GANDALF_DEPS)
 
 
@@ -869,17 +897,21 @@ def test_upgrade_changed_sets_idle_and_deps_if_some_completed_idle(harness):
     )
     harness.add_relation("upgrade", "gandalf")
 
-    assert not harness.charm.upgrade.stored_dependencies == GandalfModel(**GANDALF_DEPS)
+    assert harness.charm.upgrade.stored_dependencies != GandalfModel(**GANDALF_DEPS)
 
     harness.charm.upgrade.upgrade_stack = []
-    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "completed"})
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update(
+        {"state": UpgradeState.COMPLETED.name.lower()}
+    )
     harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/1")
-    harness.set_leader()
+    harness.set_leader(True)
     harness.update_relation_data(
-        harness.charm.upgrade.peer_relation.id, "gandalf/1", {"state": "idle"}
+        harness.charm.upgrade.peer_relation.id,
+        "gandalf/1",
+        {"state": UpgradeState.IDLE.name.lower()},
     )
 
-    assert harness.charm.upgrade.state == "idle"
+    assert harness.charm.upgrade.state == UpgradeState.IDLE
     assert harness.charm.upgrade.stored_dependencies == GandalfModel(**GANDALF_DEPS)
 
 
@@ -889,13 +921,17 @@ def test_upgrade_changed_does_not_recurse_if_called_all_idle(harness, mocker):
     )
     harness.add_relation("upgrade", "gandalf")
     harness.charm.upgrade.upgrade_stack = []
-    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "idle"})
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update(
+        {"state": UpgradeState.IDLE.name.lower()}
+    )
     harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/1")
     harness.set_leader(True)
 
     mocker.patch.object(harness.charm.upgrade, "on_upgrade_changed")
     harness.update_relation_data(
-        harness.charm.upgrade.peer_relation.id, "gandalf/1", {"state": "idle"}
+        harness.charm.upgrade.peer_relation.id,
+        "gandalf/1",
+        {"state": UpgradeState.IDLE.name.lower()},
     )
 
     harness.charm.upgrade.on_upgrade_changed.assert_called_once()
@@ -904,10 +940,10 @@ def test_upgrade_changed_does_not_recurse_if_called_all_idle(harness, mocker):
 @pytest.mark.parametrize(
     "pre_state,stack,call_count,post_state",
     [
-        ("idle", [0, 1], 0, "idle"),
-        ("idle", [1, 0], 0, "idle"),
-        ("ready", [0, 1], 0, "ready"),
-        ("ready", [1, 0], 1, "upgrading"),
+        (UpgradeState.IDLE, [0, 1], 0, UpgradeState.IDLE),
+        (UpgradeState.IDLE, [1, 0], 0, UpgradeState.IDLE),
+        (UpgradeState.READY, [0, 1], 0, UpgradeState.READY),
+        (UpgradeState.READY, [1, 0], 1, UpgradeState.UPGRADING),
     ],
 )
 def test_upgrade_changed_emits_upgrade_granted_only_if_top_of_stack(
@@ -921,12 +957,16 @@ def test_upgrade_changed_emits_upgrade_granted_only_if_top_of_stack(
         harness.add_relation("upgrade", "gandalf")
         harness.charm.upgrade.upgrade_stack = stack
         harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/1")
-        harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": pre_state})
+        harness.charm.upgrade.peer_relation.data[harness.charm.unit].update(
+            {"state": pre_state.name.lower()}
+        )
 
     upgrade_granted_spy = mocker.spy(harness.charm.upgrade, "_on_upgrade_granted")
 
     harness.update_relation_data(
-        harness.charm.upgrade.peer_relation.id, "gandalf/1", {"state": "ready"}
+        harness.charm.upgrade.peer_relation.id,
+        "gandalf/1",
+        {"state": UpgradeState.READY.name.lower()},
     )
 
     assert upgrade_granted_spy.call_count == call_count
@@ -942,16 +982,20 @@ def test_upgrade_changed_emits_upgrade_granted_only_if_all_ready(harness, mocker
         harness.add_relation("upgrade", "gandalf")
         harness.charm.upgrade.upgrade_stack = [1, 0]
         harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/1")
-        harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "ready"})
+        harness.charm.upgrade.peer_relation.data[harness.charm.unit].update(
+            {"state": UpgradeState.READY.name.lower()}
+        )
 
     upgrade_granted_spy = mocker.spy(harness.charm.upgrade, "_on_upgrade_granted")
 
     harness.update_relation_data(
-        harness.charm.upgrade.peer_relation.id, "gandalf/1", {"state": "idle"}
+        harness.charm.upgrade.peer_relation.id,
+        "gandalf/1",
+        {"state": UpgradeState.IDLE.name.lower()},
     )
 
     assert upgrade_granted_spy.call_count == 0
-    assert harness.charm.upgrade.state == "ready"
+    assert harness.charm.upgrade.state == UpgradeState.READY
 
 
 @pytest.mark.parametrize(
@@ -1015,14 +1059,18 @@ def test_upgrade_changed_recurses_on_leader_and_clears_stack(harness, mocker):
     )
     harness.add_relation("upgrade", "gandalf")
     harness.charm.upgrade.upgrade_stack = [0, 1]
-    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "ready"})
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update(
+        {"state": UpgradeState.READY.name.lower()}
+    )
     harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/1")
     harness.set_leader(True)
 
     upgrade_changed_spy = mocker.spy(harness.charm.upgrade, "on_upgrade_changed")
 
     harness.update_relation_data(
-        harness.charm.upgrade.peer_relation.id, "gandalf/1", {"state": "completed"}
+        harness.charm.upgrade.peer_relation.id,
+        "gandalf/1",
+        {"state": UpgradeState.COMPLETED.name.lower()},
     )
 
     # once for top of stack 1, once for leader 0
@@ -1039,13 +1087,17 @@ def test_upgrade_changed_does_not_recurse_or_change_stack_non_leader(harness, mo
     )
     harness.add_relation("upgrade", "gandalf")
     harness.charm.upgrade.upgrade_stack = [0, 1]
-    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "ready"})
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update(
+        {"state": UpgradeState.READY.name.lower()}
+    )
     harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/1")
 
     upgrade_changed_spy = mocker.spy(harness.charm.upgrade, "on_upgrade_changed")
 
     harness.update_relation_data(
-        harness.charm.upgrade.peer_relation.id, "gandalf/1", {"state": "completed"}
+        harness.charm.upgrade.peer_relation.id,
+        "gandalf/1",
+        {"state": UpgradeState.COMPLETED.name.lower()},
     )
 
     # once for top of stack 1
@@ -1061,17 +1113,23 @@ def test_repair_upgrade_stack_puts_failed_unit_first_in_stack(harness):
     )
     harness.add_relation("upgrade", "gandalf")
     harness.charm.upgrade.upgrade_stack = [0, 2]
-    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "ready"})
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update(
+        {"state": UpgradeState.READY.name.lower()}
+    )
     harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/1")
     harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/2")
     harness.set_leader(True)
 
     with harness.hooks_disabled():
         harness.update_relation_data(
-            harness.charm.upgrade.peer_relation.id, "gandalf/1", {"state": "completed"}
+            harness.charm.upgrade.peer_relation.id,
+            "gandalf/1",
+            {"state": UpgradeState.COMPLETED.name.lower()},
         )
         harness.update_relation_data(
-            harness.charm.upgrade.peer_relation.id, "gandalf/2", {"state": "failed"}
+            harness.charm.upgrade.peer_relation.id,
+            "gandalf/2",
+            {"state": UpgradeState.FAILED.name.lower()},
         )
 
     harness.charm.upgrade._repair_upgrade_stack()
@@ -1085,17 +1143,23 @@ def test_repair_upgrade_stack_does_not_modify_existing_stack(harness):
     )
     harness.add_relation("upgrade", "gandalf")
     harness.charm.upgrade.upgrade_stack = [0, 2, 1]
-    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update({"state": "ready"})
+    harness.charm.upgrade.peer_relation.data[harness.charm.unit].update(
+        {"state": UpgradeState.READY.name.lower()}
+    )
     harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/1")
     harness.add_relation_unit(harness.charm.upgrade.peer_relation.id, "gandalf/2")
     harness.set_leader(True)
 
     with harness.hooks_disabled():
         harness.update_relation_data(
-            harness.charm.upgrade.peer_relation.id, "gandalf/1", {"state": "failed"}
+            harness.charm.upgrade.peer_relation.id,
+            "gandalf/1",
+            {"state": UpgradeState.FAILED.name.lower()},
         )
         harness.update_relation_data(
-            harness.charm.upgrade.peer_relation.id, "gandalf/2", {"state": "ready"}
+            harness.charm.upgrade.peer_relation.id,
+            "gandalf/2",
+            {"state": UpgradeState.READY.name.lower()},
         )
 
     harness.charm.upgrade._repair_upgrade_stack()


### PR DESCRIPTION
Adds upgrade v1 which uses Pydantic 2.0+ instead of version <2.
The unit test remains same as v0 because changes between two are minimal.
Key Changes Made:

1. Simplified validate_constraint: Because we bound `VersionConstraint` directly to the str type, Pydantic will pass a string into `validate_constraint` function. All the `isinstance` checks  are removed.
2. Replaced `@root_validator` with `@model_validator(mode="after")`, because it runs after field validation, `self` is fully constructed.
3. Dropped `skip_on_failure=True`, Pydantic v2 automatically skips mode="after" model validators if any individual field validations fail
4. Updated requirements to include poetry-core
5. Replaced `self.dependency_model.__fields__.keys()` with `self.dependency_model.model_fields.keys()`
6. Replaced `self.dependency_model.dict()` with `self.dependency_model.model_dump_json()`
7. Fixed typos in database charm in integration tests(to fix linter error)
8. Implemented IntEnum for upgrade state
